### PR TITLE
[BRE-410] - Fix the No Output in Workflow_call Bug

### DIFF
--- a/src/bitwarden_workflow_linter/rules/underscore_outputs.py
+++ b/src/bitwarden_workflow_linter/rules/underscore_outputs.py
@@ -93,7 +93,8 @@ class RuleUnderscoreOutputs(Rule):
                     outputs.extend(obj.on["workflow_dispatch"]["outputs"].keys())
 
             if obj.on.get("workflow_call"):
-                outputs.extend(obj.on["workflow_call"]["outputs"].keys())
+                if obj.on["workflow_call"].get("outputs"):
+                    outputs.extend(obj.on["workflow_call"]["outputs"].keys())
 
         if isinstance(obj, Job):
             if obj.outputs:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-410
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Fix the bug when workflow_call doesn't have an output but have other keys like inputs: {}

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
