### PR TITLE
Add actionlint to workflow linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    path:
+    paths:
       - "src/**"
       - "tests/**"
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    paths:
+    path:
       - "src/**"
       - "tests/**"
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ Thumbs.db
 *.sublime-workspace
 
 # Visual Studio Code
-.vscode/*
+.vscode
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
@@ -36,3 +36,5 @@ flake.*
 **/__pycache__/**
 *.pyc
 .venv/
+.pytest_cache
+.pytype

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ flake.*
 # Python
 **/__pycache__/**
 *.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ options:
 
 -   Python 3.11
 -   pipenv
+-   Windows systems: Chocolatey package manager
+-   Mac OS systems: Homebrew package manager
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Bitwarden Workflow Linter
 
 Bitwarden's Workflow Linter is an extensible linter to apply opinionated organization-specific
-GitHub Action standards. It was designed to be used alongside tools like
-[action-lint](https://github.com/rhysd/actionlint) and
-[yamllint](https://github.com/adrienverge/yamllint) to check for correct Action syntax and enforce
+GitHub Action standards. It was designed to be used alongside
+[yamllint](https://github.com/adrienverge/yamllint) to enforce
 specific YAML standards.
 
 To see an example of Workflow Linter in practice in GitHub Action, see the

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
-        "husky": "^9.1.7",
+        "husky": "9.0.11",
         "lint-staged": "15.2.7",
         "prettier": "3.3.2"
       }
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -250,13 +250,13 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
+      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "bin.js"
+        "husky": "bin.mjs"
       },
       "engines": {
         "node": ">=18"
@@ -428,9 +428,9 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {
-        "husky": "9.0.11",
+        "husky": "^9.1.7",
         "lint-staged": "15.2.7",
         "prettier": "3.3.2"
       }
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -250,13 +250,13 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "bin.mjs"
+        "husky": "bin.js"
       },
       "engines": {
         "node": ">=18"
@@ -428,9 +428,9 @@
       "license": "MIT"
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://bitwarden.com",
   "devDependencies": {
-    "husky": "9.0.11",
+    "husky": "^9.1.7",
     "lint-staged": "15.2.7",
     "prettier": "3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://bitwarden.com",
   "devDependencies": {
-    "husky": "^9.1.7",
+    "husky": "9.0.11",
     "lint-staged": "15.2.7",
     "prettier": "3.3.2"
   },

--- a/src/bitwarden_workflow_linter/load.py
+++ b/src/bitwarden_workflow_linter/load.py
@@ -39,7 +39,12 @@ class WorkflowBuilder:
           objects (depending on their location in the file).
         """
         with open(filename, encoding="utf8") as file:
-            return yaml.load(file)
+            if not file:
+                raise WorkflowBuilderError(f"Could not load {filename}")
+            try:
+                return yaml.load(file)
+            except Exception as e:
+                raise WorkflowBuilderError(f"Error loading YAML file {filename}: {e}")
 
     @classmethod
     def __build_workflow(cls, filename: str, loaded_yaml: CommentedMap) -> Workflow:
@@ -54,7 +59,12 @@ class WorkflowBuilder:
         Returns
           A Workflow to run linting Rules against
         """
-        return Workflow.init("", filename, loaded_yaml)
+        try:
+            if not loaded_yaml:
+                raise WorkflowBuilderError("No YAML loaded")
+            return Workflow.init("", filename, loaded_yaml)
+        except Exception as e:
+            raise WorkflowBuilderError(f"Error building workflow: {e}")
 
     @classmethod
     def build(

--- a/src/bitwarden_workflow_linter/load.py
+++ b/src/bitwarden_workflow_linter/load.py
@@ -42,7 +42,7 @@ class WorkflowBuilder:
             return yaml.load(file)
 
     @classmethod
-    def __build_workflow(cls, loaded_yaml: CommentedMap) -> Workflow:
+    def __build_workflow(cls, filename: str, loaded_yaml: CommentedMap) -> Workflow:
         """Parse the YAML and build out the workflow to run Rules against.
 
         Args:
@@ -52,7 +52,7 @@ class WorkflowBuilder:
         Returns
           A Workflow to run linting Rules against
         """
-        return Workflow.init("", loaded_yaml)
+        return Workflow.init("", filename, loaded_yaml)
 
     @classmethod
     def build(
@@ -76,9 +76,11 @@ class WorkflowBuilder:
             be loaded from disk
         """
         if from_file and filename is not None:
-            return cls.__build_workflow(cls.__load_workflow_from_file(filename))
+            return cls.__build_workflow(
+                filename, cls.__load_workflow_from_file(filename)
+            )
         elif not from_file and workflow is not None:
-            return cls.__build_workflow(workflow)
+            return cls.__build_workflow(None, workflow)
 
         raise WorkflowBuilderError(
             "The workflow must either be built from a file or from a CommentedMap"

--- a/src/bitwarden_workflow_linter/load.py
+++ b/src/bitwarden_workflow_linter/load.py
@@ -46,6 +46,8 @@ class WorkflowBuilder:
         """Parse the YAML and build out the workflow to run Rules against.
 
         Args:
+          filename:
+            The name of the file that the YAML was loaded from
           loaded_yaml:
             YAML that was loaded from either code or a file
 

--- a/src/bitwarden_workflow_linter/load.py
+++ b/src/bitwarden_workflow_linter/load.py
@@ -82,7 +82,7 @@ class WorkflowBuilder:
                 filename, cls.__load_workflow_from_file(filename)
             )
         elif not from_file and workflow is not None:
-            return cls.__build_workflow(None, workflow)
+            return cls.__build_workflow("", workflow)
 
         raise WorkflowBuilderError(
             "The workflow must either be built from a file or from a CommentedMap"

--- a/src/bitwarden_workflow_linter/models/workflow.py
+++ b/src/bitwarden_workflow_linter/models/workflow.py
@@ -23,14 +23,16 @@ class Workflow:
     """
 
     key: str = ""
+    filename: Optional[str] = None
     name: Optional[str] = None
     on: Optional[CommentedMap] = None
     jobs: Optional[Dict[str, Job]] = None
 
     @classmethod
-    def init(cls: Self, key: str, data: CommentedMap) -> Self:
+    def init(cls: Self, key: str, filename: str, data: CommentedMap) -> Self:
         init_data = {
             "key": key,
+            "filename": filename,
             "name": data["name"] if "name" in data else None,
             "on": data["on"] if "on" in data else None,
         }

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -38,7 +38,7 @@ def check_actionlint():
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Homebrew installation or manually install it."
                 return False, error
-        elif Platform == 'Windows':
+        elif Platform.startswith('Win'):
             try:
                 subprocess.run(['choco', 'install', 'actionlint', '-y'], check=True)
                 return True, ""

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -37,7 +37,8 @@ please check your package installer or manually install it",
             version = '1.6.17'
             request = urllib.request.urlopen(url)
             with open('download-actionlint.bash', 'wb+') as fp:
-                fp.write(request.read())
+                # fp.write(request.read())
+                print(request.read())
             try:
                 subprocess.run(
                     ['bash', ['install-actionlint.bash', version]], check=True)

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -68,4 +68,5 @@ class RunActionlint(Rule):
                 return False, result.stderr
             return True, ""
         else:
+            print(install_error)
             return False, install_error

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -31,6 +31,7 @@ def install_actionlint(platform_system: str) -> Tuple[bool, str]:
             return True, ""
         except (FileNotFoundError, subprocess.CalledProcessError):
             return False, f"{error} : check Choco installation"
+    return False, error
 
 
 def install_actionlint_source(error) -> Tuple[bool, str]:

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -10,7 +10,7 @@ from ..models.workflow import Workflow
 from ..utils import LintLevels, Settings
 
 
-def check_actionlint() -> Tuple[bool, str]:
+def check_actionlint():
     """Check if the actionlint is in the system's PATH.
     
     If actionlint is not installed, detects OS platform 
@@ -19,31 +19,31 @@ def check_actionlint() -> Tuple[bool, str]:
     Platform = platform.system()
     try:
         subprocess.run(["actionlint", '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-        return True
+        return True, ""
     except subprocess.CalledProcessError:
-        return False
+        return False, "Failed to install Actionlint, please check your package installer or manually install it"
     except FileNotFoundError:
         if Platform.startswith('Linux'):
             try:
                 subprocess.run(['sudo', 'apt-get', 'install', '-y', 'actionlint'], check=True)
-                return [True, ""]
+                return True, ""
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your package manager or manually install it."
-                return [False, error]
+                return False, error
         elif Platform == 'Darwin':
             try:
                 subprocess.run(['brew', 'install', 'actionlint'], check=True)
-                return [True, ""]
+                return True, ""
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Homebrew installation or manually install it."
-                return [False, error]
+                return False, error
         elif Platform == 'Win32':
             try:
                 subprocess.run(['choco', 'install', 'actionlint', '-y'], check=True)
-                return [True, ""]
+                return True, ""
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Chocolatey installation or manually install it."
-                return [False, error]
+                return False, error
             
 class RunActionlint(Rule):
     """Rule to run actionlint as part of workflow linter V2.

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -3,7 +3,7 @@
 from typing import Optional, Tuple
 import subprocess
 import platform
-import urllib
+import urllib.request
 
 from ..rule import Rule
 from ..models.workflow import Workflow

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -35,7 +35,7 @@ please check your package installer or manually install it",
         if platform_system.startswith("Linux"):
             try:
                 subprocess.run(
-                    ["apt", "update", "&&", "sudo", "apt-get", "install", "-y", "actionlint"], check=True
+                    ["sudo", "apt-get", "update", "&&", "sudo", "apt-get", "install", "-y", "actionlint"], check=True
                 )
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
@@ -72,15 +72,14 @@ class RunActionlint(Rule):
 
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
         if not obj.filename:
-            raise NotImplementedError(
-                "Running actionlint without a filename is not currently supported"
-            )
+            raise NotImplementedError("Running actionlint without a filename is not currently supported")
         installed, install_error = check_actionlint()
         if installed:
             result = subprocess.run(
                 ["actionlint", obj.filename],
                 capture_output=True,
                 text=True,
+                check=False,
             )
             if result.returncode == 1:
                 print(result.stdout)

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -3,6 +3,7 @@
 from typing import Optional, Tuple
 import subprocess
 import platform
+import shutil
 
 from ..rule import Rule
 from ..models.workflow import Workflow
@@ -14,11 +15,11 @@ def actionlint_download():
     download_path = "/tmp/actionlint"
 
     print("Downloading actionlint...")
-    subprocess.run(["curl", "-L", url, "-o", download_path], check=True)
+    subprocess.run(["sudo", "curl", "-L", url, "-o", download_path], check=True)
 
     # Step 2: Make the binary executable
     print("Making actionlint executable...")
-    subprocess.run(["chmod", "+x", download_path], check=True)
+    subprocess.run(["sudo", "chmod", "+x", download_path], check=True)
 
     # Step 3: Move the binary to a directory in the PATH (e.g., /usr/local/bin)
     target_path = "/usr/local/bin/actionlint"

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -4,17 +4,34 @@ from typing import Optional, Tuple
 import subprocess
 import platform
 import urllib.request
+import os
 
 from ..rule import Rule
 from ..models.workflow import Workflow
 from ..utils import LintLevels, Settings
 
-def check_actionlint():
-    """Check if the actionlint is in the system's PATH.
+def install_actionlint_package():
+    """If actionlint is not installed, detects OS platform
+    and installs actionlint"""
+    
+def install_actionlint_source():
+    """Install Actionlint Binary from provided script"""
+    url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
+    version = '1.6.17'
+    request = urllib.request.urlopen(url)
+    with open('download-actionlint.bash', 'wb+') as fp:
+            fp.write(request.read())
+    try:
+        subprocess.run(
+            ['bash', 'download-actionlint.bash', version], check=True)
+        return True, "", os.getcwd()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        error = "Failed to install Actionlint. \
+Please check your package manager or manually install it."
+        return False, error, ""
 
-    If actionlint is not installed, detects OS platform
-    and installs actionlint
-    """
+def check_actionlint():
+    """Check if the actionlint is in the system's PATH."""
     platform_system = platform.system()
     error = f"An unknown error occurred on platform {platform_system}"
     try:
@@ -24,7 +41,7 @@ def check_actionlint():
             stderr=subprocess.PIPE,
             check=True,
         )
-        return True, ""
+        return True, "", ""
     except subprocess.CalledProcessError:
         return (
             False,
@@ -33,44 +50,25 @@ please check your package installer or manually install it",
         )
     except FileNotFoundError:
         if platform_system.startswith("Linux"):
-            url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
-            version = '1.6.17'
-            request = urllib.request.urlopen(url)
-            try:
-                with open('download-actionlint.bash', 'wb+') as fp:
-                    fp.write(request.read())
-                    print("got to with open")
-                    result = subprocess.run(
-                        ['install-actionlint.bash', version], check=True, capture_output=True,
-                    text=True,)
-                    print('******')
-                    print(result.stdout)
-                    print('******')
-                    return True, ""
-            except (FileNotFoundError, subprocess.CalledProcessError):
-                print('******')
-                print(result.stdout)
-                print('******')
-                error = "Failed to install Actionlint1. \
-Please check your package manager or manually install it."
-                return False, error
+            return install_actionlint_source()
         elif platform_system == "Darwin":
-            try:
-                subprocess.run(["brew", "install", "actionlint"], check=True)
-                return True, ""
-            except (FileNotFoundError, subprocess.CalledProcessError):
-                error = "Failed to install Actionlint. \
-Please check your Homebrew installation or manually install it."
-                return False, error
+            return install_actionlint_source()
+#             try:
+#                 subprocess.run(["brew", "install", "actionlint"], check=True)
+#                 return True, ""
+#             except (FileNotFoundError, subprocess.CalledProcessError):
+#                 error = "Failed to install Actionlint. \
+# Please check your Homebrew installation or manually install it."
+#                 return False, error
         elif platform_system.startswith("Win"):
             try:
                 subprocess.run(["choco", "install", "actionlint", "-y"], check=True)
-                return True, ""
+                return True, "", ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \
 Please check your Chocolatey installation or manually install it."
-                return False, error
-    return False, 'whoops'
+                return False, error, ""
+    return False, error, ""
 
 
 class RunActionlint(Rule):
@@ -85,13 +83,21 @@ class RunActionlint(Rule):
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
         if not obj.filename:
             raise NotImplementedError("Running actionlint without a filename is not currently supported")
-        installed, install_error = check_actionlint()
+        installed, install_error, location = check_actionlint()
         if installed:
-            result = subprocess.run(
-                ["actionlint", obj.filename],
+            if location:
+                result = subprocess.run(
+                [location + "/actionlint", obj.filename],
                 capture_output=True,
                 text=True,
                 check=False,
+            )
+            else:
+                result = subprocess.run(
+                    ["actionlint", obj.filename],
+                    capture_output=True,
+                    text=True,
+                    check=False,
             )
             if result.returncode == 1:
                 print(result.stdout)

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -43,7 +43,9 @@ please check your package installer or manually install it",
                 result = subprocess.run(
                     ['install-actionlint.bash', version], check=True, capture_output=True,
                 text=True,)
+                print('******')
                 print(result.stdout)
+                print('******')
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -100,7 +100,7 @@ class RunActionlint(Rule):
                     text=True,
                     check=False)
             if result.returncode == 1:
-                print(result.stdout)
+                return False, result.stdout
             if result.returncode > 1:
                 return False, result.stdout
             return True, ""

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -48,6 +48,7 @@ please check your package installer or manually install it",
                     print('******')
                     return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
+                print(result.stdout)
                 error = "Failed to install Actionlint1. \
 Please check your package manager or manually install it."
                 return False, error

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -40,14 +40,14 @@ please check your package installer or manually install it",
                 fp.write(request.read())
                 # print(request.read)
             try:
-                subprocess.run(
+                result = subprocess.run(
                     ['install-actionlint.bash', version], check=True, capture_output=True,
-                text=True)
+                text=True,)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \
 Please check your package manager or manually install it."
-                return False, error
+                return False, result.stdout
         elif platform_system == "Darwin":
             try:
                 subprocess.run(["brew", "install", "actionlint"], check=True)
@@ -58,12 +58,11 @@ Please check your Homebrew installation or manually install it."
                 return False, error
         elif platform_system.startswith("Win"):
             try:
-                result = subprocess.run(["choco", "install", "actionlint", "-y"], check=True)
+                subprocess.run(["choco", "install", "actionlint", "-y"], check=True)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
-                error = result.stdout
-                # error = "Failed to install Actionlint. \
-# Please check your Chocolatey installation or manually install it."
+                error = "Failed to install Actionlint. \
+Please check your Chocolatey installation or manually install it."
                 return False, error
     return False, error
 

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -72,14 +72,15 @@ class RunActionlint(Rule):
 
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
         if not obj.filename:
-            raise NotImplementedError("Running actionlint without a filename is not currently supported")
+            raise NotImplementedError(
+                "Running actionlint without a filename is not currently supported"
+            )
         installed, install_error = check_actionlint()
         if installed:
             result = subprocess.run(
                 ["actionlint", obj.filename],
                 capture_output=True,
                 text=True,
-                check=False,
             )
             if result.returncode == 1:
                 print(result.stdout)

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -3,39 +3,11 @@
 from typing import Optional, Tuple
 import subprocess
 import platform
-import shutil
+import urllib
 
 from ..rule import Rule
 from ..models.workflow import Workflow
 from ..utils import LintLevels, Settings
-
-def actionlint_download():
-    # Step 1: Download the actionlint binary
-    url = "https://github.com/rhysd/actionlint/releases/download/v1.6.18/actionlint-linux-amd64"
-    download_path = "/tmp/actionlint"
-
-    print("Downloading actionlint...")
-    subprocess.run(["sudo", "curl", "-L", url, "-o", download_path], check=True)
-
-    # Step 2: Make the binary executable
-    print("Making actionlint executable...")
-    subprocess.run(["sudo", "chmod", "+x", download_path], check=True)
-
-    # Step 3: Move the binary to a directory in the PATH (e.g., /usr/local/bin)
-    target_path = "/usr/local/bin/actionlint"
-    print(f"Moving actionlint to {target_path}...")
-    shutil.move(download_path, target_path)
-
-    # Verify installation
-    print("Verifying installation...")
-    result = subprocess.run(["actionlint", "--version"], capture_output=True, text=True)
-    
-    if result.returncode == 0:
-        print("actionlint installed successfully!")
-        print(f"Version: {result.stdout.strip()}")
-    else:
-        print("Error occurred during installation.")
-        print(result.stderr)
 
 def check_actionlint():
     """Check if the actionlint is in the system's PATH.
@@ -61,8 +33,14 @@ please check your package installer or manually install it",
         )
     except FileNotFoundError:
         if platform_system.startswith("Linux"):
+            url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
+            version = '1.6.17'
+            request = urllib.request.open(url)
+            with open('download-actionlint.bash', 'w+') as fp:
+                fp.write(request.read())
             try:
-                actionlint_download()
+                subprocess.run(
+                    ['bash', ['install-actionlint.bash', version]], check=True)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -41,7 +41,8 @@ please check your package installer or manually install it",
                 # print(request.read)
             try:
                 subprocess.run(
-                    ['install-actionlint.bash', version], check=True)
+                    ['install-actionlint.bash', version], check=True, capture_output=True,
+                text=True)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \
@@ -57,11 +58,12 @@ Please check your Homebrew installation or manually install it."
                 return False, error
         elif platform_system.startswith("Win"):
             try:
-                subprocess.run(["choco", "install", "actionlint", "-y"], check=True)
+                result = subprocess.run(["choco", "install", "actionlint", "-y"], check=True)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
-                error = "Failed to install Actionlint. \
-Please check your Chocolatey installation or manually install it."
+                error = result.stdout
+                # error = "Failed to install Actionlint. \
+# Please check your Chocolatey installation or manually install it."
                 return False, error
     return False, error
 

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -44,9 +44,9 @@ def check_actionlint():
 class RunActionlint(Rule):
     def __init__(self, settings: Settings = None) -> None:
         self.message = "Actionlint must pass without errors"
-        self.on_fail: LintLevels = LintLevels.WARNING
-        self.compatibility = [Workflow, Job, Step]
-        self.settings: Settings = settings
+        self.on_fail = LintLevels.WARNING
+        self.compatibility = [Workflow]
+        self.settings = settings
 
     def fn(self, obj: Job) -> Tuple[bool, str]:
         if check_actionlint():

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -35,7 +35,10 @@ please check your package installer or manually install it",
         if platform_system.startswith("Linux"):
             try:
                 subprocess.run(
-                    ["sudo", "apt-get", "update", "&&", "sudo", "apt-get", "install", "-y", "actionlint"], check=True
+                    ["sudo", "apt-get", "update"], check=True
+                )
+                subprocess.run(
+                    ["sudo", "apt-get", "install", "-y", "actionlint"], check=True
                 )
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -3,6 +3,7 @@
 from typing import Optional, Tuple
 import subprocess
 import platform
+import pprint
 
 from ..rule import Rule
 from ..models.workflow import Workflow
@@ -73,24 +74,12 @@ class RunActionlint(Rule):
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
         installed, install_error = check_actionlint()
         if installed:
-            if obj.filename:
-                result = subprocess.run(
-                    ["actionlint", obj.filename],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-            else:
-                # Need to update this to use the YAML string from the workflow
-                # yaml.dump(obj.on)
-                
-                result = subprocess.run(
-                    ["actionlint", "-"],
-                    input="../gh-actions/.github/workflows",
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
+            result = subprocess.run(
+                ["actionlint", obj.filename],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
             if result.returncode == 1:
                 print(result.stdout)
                 return False, self.message

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -72,6 +72,8 @@ class RunActionlint(Rule):
         self.settings = settings
 
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
+        if not obj.filename:
+            raise NotImplementedError("Running actionlint without a filename is not currently supported")
         installed, install_error = check_actionlint()
         if installed:
             result = subprocess.run(

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -44,7 +44,7 @@ def check_actionlint():
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Chocolatey installation or manually install it."
                 return False, error
-    return False, "An unknown error occurred"
+    return False, "An unknown error occurred on platform {Platform}"
             
 class RunActionlint(Rule):
     """Rule to run actionlint as part of workflow linter V2.

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -37,11 +37,11 @@ please check your package installer or manually install it",
             version = '1.6.17'
             request = urllib.request.urlopen(url)
             with open('download-actionlint.bash', 'wb+') as fp:
-                # fp.write(request.read())
-                print(request.read())
+                fp.write(request.read())
+                # print(request.read)
             try:
                 subprocess.run(
-                    ['bash', ['install-actionlint.bash', version]], check=True)
+                    ['install-actionlint.bash', version], check=True)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -36,7 +36,7 @@ please check your package installer or manually install it",
             url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
             version = '1.6.17'
             request = urllib.request.urlopen(url)
-            with open('download-actionlint.bash', 'w+') as fp:
+            with open('download-actionlint.bash', 'wb+') as fp:
                 fp.write(request.read())
             try:
                 subprocess.run(

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -99,8 +99,10 @@ class RunActionlint(Rule):
                     capture_output=True,
                     text=True,
                     check=False)
-            if result.returncode != 0:
-                return False, self.message
+            if result.returncode == 1:
+                print(result.stdout)
+            if result.returncode > 1:
+                return False, result.stdout
             return True, ""
         else:
             return False, self.message

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -83,9 +83,10 @@ class RunActionlint(Rule):
             else:
                 # Need to update this to use the YAML string from the workflow
                 # yaml.dump(obj.on)
+                
                 result = subprocess.run(
                     ["actionlint", "-"],
-                    input="",
+                    input="../gh-actions/.github/workflows",
                     capture_output=True,
                     text=True,
                     check=False,

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -10,55 +10,51 @@ from ..rule import Rule
 from ..models.workflow import Workflow
 from ..utils import LintLevels, Settings
 
-def install_actionlint():
+
+def install_actionlint(platform_system: str) -> Tuple[bool, str]:
     """If actionlint is not installed, detects OS platform
     and installs actionlint"""
-    platform_system = platform.system()
-    error = f"An unknown error occurred on platform {platform_system}"
+
+    error = f"An error occurred when installing Actionlint on {platform_system}"
 
     if platform_system.startswith("Linux"):
-        return install_actionlint_source()
+        return install_actionlint_source(error)
     elif platform_system == "Darwin":
         try:
             subprocess.run(["brew", "install", "actionlint"], check=True)
             return True, ""
         except (FileNotFoundError, subprocess.CalledProcessError):
-            error = "Failed to install Actionlint. \
-Please check your Homebrew installation or manually install it."
-            return False, error
+            return False, f"{error} : check Brew installation"
     elif platform_system.startswith("Win"):
         try:
             subprocess.run(["choco", "install", "actionlint", "-y"], check=True)
             return True, ""
         except (FileNotFoundError, subprocess.CalledProcessError):
-            error = "Failed to install Actionlint. \
-Please check your Chocolatey installation or manually install it."
-            return False, error
-    
-def install_actionlint_source():
+            return False, f"{error} : check Choco installation"
+
+
+def install_actionlint_source(error) -> Tuple[bool, str]:
     """Install Actionlint Binary from provided script"""
     url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
-    version = '1.6.17'
+    version = "1.6.17"
     request = urllib.request.urlopen(url)
-    with open('download-actionlint.bash', 'wb+') as fp:
-            fp.write(request.read())
+    with open("download-actionlint.bash", "wb+") as fp:
+        fp.write(request.read())
     try:
-        subprocess.run(
-            ['bash', 'download-actionlint.bash', version], check=True)
+        subprocess.run(["bash", "download-actionlint.bash", version], check=True)
         return True, os.getcwd()
     except (FileNotFoundError, subprocess.CalledProcessError):
-        error = "Failed to install Actionlint. \
-Please check your package manager or manually install it."
         return False, error
 
-def check_actionlint():
+
+def check_actionlint(platform_system: str) -> Tuple[bool, str]:
     """Check if the actionlint is in the system's PATH."""
     try:
         subprocess.run(
             ["actionlint", "--version"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            check=True
+            check=True,
         )
         return True, ""
     except subprocess.CalledProcessError:
@@ -68,7 +64,7 @@ def check_actionlint():
 please check your package installer or manually install it",
         )
     except FileNotFoundError:
-        return install_actionlint()
+        return install_actionlint(platform_system)
 
 
 class RunActionlint(Rule):
@@ -81,24 +77,27 @@ class RunActionlint(Rule):
         self.settings = settings
 
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
-        try: 
-            filename=obj.filename
-        except AttributeError:
-            raise NotImplementedError("Running actionlint without a filename is not currently supported")
-        installed, location = check_actionlint()
+        if not obj or not obj.filename:
+            raise AttributeError(
+                "Running actionlint without a filename is not currently supported"
+            )
+
+        installed, location = check_actionlint(platform.system())
         if installed:
             if location:
                 result = subprocess.run(
-                [location + "/actionlint", obj.filename],
-                capture_output=True,
-                text=True,
-                check=False)
+                    [location + "/actionlint", obj.filename],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
             else:
                 result = subprocess.run(
                     ["actionlint", obj.filename],
                     capture_output=True,
                     text=True,
-                    check=False)
+                    check=False,
+                )
             if result.returncode == 1:
                 return False, result.stdout
             if result.returncode > 1:

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -3,7 +3,6 @@
 from typing import Optional, Tuple
 import subprocess
 import platform
-import pprint
 
 from ..rule import Rule
 from ..models.workflow import Workflow

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -44,6 +44,7 @@ def check_actionlint():
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Chocolatey installation or manually install it."
                 return False, error
+    return False, "An unknown error occurred"
             
 class RunActionlint(Rule):
     """Rule to run actionlint as part of workflow linter V2.

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -73,7 +73,6 @@ class RunActionlint(Rule):
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
         installed, install_error = check_actionlint()
         if installed:
-            print(obj.on)
             if obj.filename:
                 result = subprocess.run(
                     ["actionlint", obj.filename],

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -92,21 +92,15 @@ class RunActionlint(Rule):
                 [location + "/actionlint", obj.filename],
                 capture_output=True,
                 text=True,
-                check=False,
-            )
+                check=False)
             else:
                 result = subprocess.run(
                     ["actionlint", obj.filename],
                     capture_output=True,
                     text=True,
-                    check=False,
-            )
-            if result.returncode == 1:
-                print(result.stdout)
+                    check=False)
+            if result.returncode != 0:
                 return False, self.message
-            elif result.returncode > 1:
-                return False, result.stderr
             return True, ""
         else:
-            print(result)
-            return False, result
+            return False, self.message

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -81,13 +81,15 @@ class RunActionlint(Rule):
         self.settings = settings
 
     def fn(self, obj: Workflow) -> Tuple[bool, str]:
-        if not obj.filename:
+        try: 
+            filename=obj.filename
+        except AttributeError:
             raise NotImplementedError("Running actionlint without a filename is not currently supported")
-        installed, result = check_actionlint()
+        installed, location = check_actionlint()
         if installed:
-            if result:
+            if location:
                 result = subprocess.run(
-                [result + "/actionlint", obj.filename],
+                [location + "/actionlint", obj.filename],
                 capture_output=True,
                 text=True,
                 check=False,

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -1,12 +1,10 @@
-from typing import Union, Tuple
+from typing import Optional, Tuple
 import subprocess
 import platform
-import shutil
 
 from ..rule import Rule
 from ..models.job import Job
 from ..models.workflow import Workflow
-from ..models.step import Step
 from ..utils import LintLevels, Settings
 
 
@@ -42,7 +40,7 @@ def check_actionlint():
                 return False
             
 class RunActionlint(Rule):
-    def __init__(self, settings: Settings = None) -> None:
+    def __init__(self, settings: Optional[Settings] = None) -> None:
         self.message = "Actionlint must pass without errors"
         self.on_fail = LintLevels.WARNING
         self.compatibility = [Workflow]

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -43,11 +43,12 @@ please check your package installer or manually install it",
                 result = subprocess.run(
                     ['install-actionlint.bash', version], check=True, capture_output=True,
                 text=True,)
+                print(result.stdout)
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \
 Please check your package manager or manually install it."
-                return False, result.stdout
+                return False, error
         elif platform_system == "Darwin":
             try:
                 subprocess.run(["brew", "install", "actionlint"], check=True)

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -1,3 +1,5 @@
+"""A Rule to run actionlint on workflows."""
+
 from typing import Optional, Tuple
 import subprocess
 import platform
@@ -9,7 +11,11 @@ from ..utils import LintLevels, Settings
 
 
 def check_actionlint():
-    """Check if the actionlint is in the system's PATH."""
+    """Check if the actionlint is in the system's PATH.
+    
+    If actionlint is not installed, detects OS platform 
+    and installs actionlint
+    """
     Platform = platform.system()
     try:
         subprocess.run(["actionlint", '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
@@ -40,6 +46,9 @@ def check_actionlint():
                 return False
             
 class RunActionlint(Rule):
+    """Rule to run actionlint as part of workflow linter V2.
+    """
+    
     def __init__(self, settings: Optional[Settings] = None) -> None:
         self.message = "Actionlint must pass without errors"
         self.on_fail = LintLevels.WARNING

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -17,6 +17,7 @@ def check_actionlint():
     and installs actionlint
     """
     Platform = platform.system()
+    error = f"An unknown error occurred on platform {Platform}"
     try:
         subprocess.run(["actionlint", '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
         return True, ""
@@ -44,7 +45,7 @@ def check_actionlint():
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Chocolatey installation or manually install it."
                 return False, error
-    return False, "An unknown error occurred on platform {Platform}"
+    return False, error
             
 class RunActionlint(Rule):
     """Rule to run actionlint as part of workflow linter V2.

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -12,8 +12,8 @@ from ..utils import LintLevels, Settings
 
 def check_actionlint():
     """Check if the actionlint is in the system's PATH.
-    
-    If actionlint is not installed, detects OS platform 
+
+    If actionlint is not installed, detects OS platform
     and installs actionlint
     """
     Platform = platform.system()
@@ -28,25 +28,25 @@ def check_actionlint():
             try:
                 subprocess.run(['sudo', 'apt-get', 'install', '-y', 'actionlint'], check=True)
                 return True, ""
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. Please check your package manager or manually install it."
                 return False, error
         elif Platform == 'Darwin':
             try:
                 subprocess.run(['brew', 'install', 'actionlint'], check=True)
                 return True, ""
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. Please check your Homebrew installation or manually install it."
                 return False, error
         elif Platform.startswith('Win'):
             try:
                 subprocess.run(['choco', 'install', 'actionlint', '-y'], check=True)
                 return True, ""
-            except subprocess.CalledProcessError:
+            except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. Please check your Chocolatey installation or manually install it."
                 return False, error
     return False, error
-            
+
 class RunActionlint(Rule):
     """Rule to run actionlint as part of workflow linter V2.
     """

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -38,7 +38,7 @@ please check your package installer or manually install it",
             request = urllib.request.urlopen(url)
             with open('download-actionlint.bash', 'wb+') as fp:
                 fp.write(request.read())
-                # print(request.read)
+                print("got to with open")
             try:
                 result = subprocess.run(
                     ['install-actionlint.bash', version], check=True, capture_output=True,
@@ -48,7 +48,7 @@ please check your package installer or manually install it",
                 print('******')
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
-                error = "Failed to install Actionlint. \
+                error = "Failed to install Actionlint1. \
 Please check your package manager or manually install it."
                 return False, error
         elif platform_system == "Darwin":
@@ -67,7 +67,7 @@ Please check your Homebrew installation or manually install it."
                 error = "Failed to install Actionlint. \
 Please check your Chocolatey installation or manually install it."
                 return False, error
-    return False, error
+    return False, 'whoops'
 
 
 class RunActionlint(Rule):

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -35,7 +35,7 @@ please check your package installer or manually install it",
         if platform_system.startswith("Linux"):
             try:
                 subprocess.run(
-                    ["sudo", "apt", "install", "-y", "actionlint"], check=True
+                    ["apt", "update", "&&", "sudo", "apt-get", "install", "-y", "actionlint"], check=True
                 )
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -35,7 +35,7 @@ please check your package installer or manually install it",
         if platform_system.startswith("Linux"):
             try:
                 subprocess.run(
-                    ["sudo", "apt-get", "install", "-y", "actionlint"], check=True
+                    ["sudo", "apt", "install", "-y", "actionlint"], check=True
                 )
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -48,7 +48,9 @@ please check your package installer or manually install it",
                     print('******')
                     return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
+                print('******')
                 print(result.stdout)
+                print('******')
                 error = "Failed to install Actionlint1. \
 Please check your package manager or manually install it."
                 return False, error

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -37,7 +37,7 @@ def check_actionlint():
             except subprocess.CalledProcessError:
                 error = "Failed to install Actionlint. Please check your Homebrew installation or manually install it."
                 return False, error
-        elif Platform == 'Win32':
+        elif Platform == 'Windows':
             try:
                 subprocess.run(['choco', 'install', 'actionlint', '-y'], check=True)
                 return True, ""
@@ -66,5 +66,4 @@ class RunActionlint(Rule):
                 return False, result.stderr
             return True, ""
         else:
-            print(install_error)
-            return False, ""
+            return False, install_error

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -36,10 +36,10 @@ please check your package installer or manually install it",
             url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
             version = '1.6.17'
             request = urllib.request.urlopen(url)
-            with open('download-actionlint.bash', 'wb+') as fp:
-                fp.write(request.read())
-                print("got to with open")
             try:
+                with open('download-actionlint.bash', 'wb+') as fp:
+                    fp.write(request.read())
+                    print("got to with open")
                 result = subprocess.run(
                     ['install-actionlint.bash', version], check=True, capture_output=True,
                 text=True,)

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -85,6 +85,7 @@ class RunActionlint(Rule):
             raise NotImplementedError("Running actionlint without a filename is not currently supported")
         installed, install_error, location = check_actionlint()
         if installed:
+            result = None
             if location:
                 result = subprocess.run(
                 [location + "/actionlint", obj.filename],

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -8,6 +8,33 @@ from ..rule import Rule
 from ..models.workflow import Workflow
 from ..utils import LintLevels, Settings
 
+def actionlint_download():
+    # Step 1: Download the actionlint binary
+    url = "https://github.com/rhysd/actionlint/releases/download/v1.6.18/actionlint-linux-amd64"
+    download_path = "/tmp/actionlint"
+
+    print("Downloading actionlint...")
+    subprocess.run(["curl", "-L", url, "-o", download_path], check=True)
+
+    # Step 2: Make the binary executable
+    print("Making actionlint executable...")
+    subprocess.run(["chmod", "+x", download_path], check=True)
+
+    # Step 3: Move the binary to a directory in the PATH (e.g., /usr/local/bin)
+    target_path = "/usr/local/bin/actionlint"
+    print(f"Moving actionlint to {target_path}...")
+    shutil.move(download_path, target_path)
+
+    # Verify installation
+    print("Verifying installation...")
+    result = subprocess.run(["actionlint", "--version"], capture_output=True, text=True)
+    
+    if result.returncode == 0:
+        print("actionlint installed successfully!")
+        print(f"Version: {result.stdout.strip()}")
+    else:
+        print("Error occurred during installation.")
+        print(result.stderr)
 
 def check_actionlint():
     """Check if the actionlint is in the system's PATH.
@@ -34,12 +61,7 @@ please check your package installer or manually install it",
     except FileNotFoundError:
         if platform_system.startswith("Linux"):
             try:
-                subprocess.run(
-                    ["sudo", "apt-get", "update"], check=True
-                )
-                subprocess.run(
-                    ["sudo", "apt-get", "install", "-y", "actionlint"], check=True
-                )
+                actionlint_download()
                 return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint. \

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -40,13 +40,13 @@ please check your package installer or manually install it",
                 with open('download-actionlint.bash', 'wb+') as fp:
                     fp.write(request.read())
                     print("got to with open")
-                result = subprocess.run(
-                    ['install-actionlint.bash', version], check=True, capture_output=True,
-                text=True,)
-                print('******')
-                print(result.stdout)
-                print('******')
-                return True, ""
+                    result = subprocess.run(
+                        ['install-actionlint.bash', version], check=True, capture_output=True,
+                    text=True,)
+                    print('******')
+                    print(result.stdout)
+                    print('******')
+                    return True, ""
             except (FileNotFoundError, subprocess.CalledProcessError):
                 error = "Failed to install Actionlint1. \
 Please check your package manager or manually install it."

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -35,7 +35,7 @@ please check your package installer or manually install it",
         if platform_system.startswith("Linux"):
             url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
             version = '1.6.17'
-            request = urllib.request.open(url)
+            request = urllib.request.urlopen(url)
             with open('download-actionlint.bash', 'w+') as fp:
                 fp.write(request.read())
             try:

--- a/tests/fixtures/test_workflow.yaml
+++ b/tests/fixtures/test_workflow.yaml
@@ -1,0 +1,32 @@
+name: test
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  job-key:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo test
+
+  call-workflow:
+    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
+
+  test-normal-action:
+    name: Download Latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - run: |
+          echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump

--- a/tests/fixtures/test_workflow_incorrect.yaml
+++ b/tests/fixtures/test_workflow_incorrect.yaml
@@ -1,0 +1,32 @@
+name: test
+on:
+  workflow_dispatch:
+  pull_request:
+
+job:
+  job-key:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo test
+
+  call-workflow:
+    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
+
+  test-normal-action:
+    name: Download Latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - run: |
+          echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump

--- a/tests/fixtures/test_workflow_incorrect.yaml
+++ b/tests/fixtures/test_workflow_incorrect.yaml
@@ -1,9 +1,13 @@
 name: test
 on:
+  push:
+    branches:
+      - 
+    path:
+      - "src/**"
   workflow_dispatch:
-  pull_request:
 
-job:
+jobs:
   job-key:
     name: Test
     runs-on: ubuntu-latest

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -9,22 +9,9 @@ from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
 
 yaml = YAML()
 
-
-# @pytest.fixture(name="correct_workflow")
-# def fixture_correct_workflow():
-#     workflow = "tests/fixtures/test_workflow.yaml"
-#     return WorkflowBuilder.build(workflow)
-
-
-# @pytest.fixture(name="incorrect_workflow")
-# def fixture_incorrect_workflow():
-#     workflow = "tests/fixtures/test_workflow_incorrect.yaml"
-#     return WorkflowBuilder.build(workflow)
-
 @pytest.fixture(name="rule")
 def fixture_rule():
     return RunActionlint()
-
 
 def test_rule_on_correct_workflow(rule):
     correct_workflow =  WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -9,6 +9,7 @@ from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
 
 yaml = YAML()
 
+
 @pytest.fixture(name="correct_workflow")
 def fixture_correct_workflow():
     workflow = """\
@@ -47,7 +48,6 @@ jobs:
         uses: ./version-bump
 """
     return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
-
 
 
 @pytest.fixture(name="incorrect_workflow")
@@ -89,14 +89,17 @@ jobs:
 """
     return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
 
+
 @pytest.fixture(name="rule")
 def fixture_rule():
     return RunActionlint()
+
 
 def test_rule_on_correct_workflow(rule, correct_workflow):
     result, _ = rule.fn(correct_workflow)
     assert result is True
 
-def test_rule_on_correct_workflow(rule, incorrect_workflow):
+
+def test_rule_on_incorrect_workflow(rule, incorrect_workflow):
     result, _ = rule.fn(incorrect_workflow)
     assert result is False

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -9,17 +9,21 @@ from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
 
 yaml = YAML()
 
+
 @pytest.fixture(name="rule")
 def fixture_rule():
     return RunActionlint()
 
+
 def test_rule_on_correct_workflow(rule):
-    correct_workflow =  WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
+    correct_workflow = WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
     result, _ = rule.fn(correct_workflow)
     assert result is True
 
 
 def test_rule_on_incorrect_workflow(rule):
-    incorrect_workflow = WorkflowBuilder.build("tests/fixtures/test_workflow_incorrect.yaml")
+    incorrect_workflow = WorkflowBuilder.build(
+        "tests/fixtures/test_workflow_incorrect.yaml"
+    )
     result, _ = rule.fn(incorrect_workflow)
     assert result is False

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -1,11 +1,17 @@
 """Test src/bitwarden_workflow_linter/rules/run_actionlint."""
 
 import pytest
+import subprocess
 
 from ruamel.yaml import YAML
 
 from src.bitwarden_workflow_linter.load import WorkflowBuilder
-from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
+from src.bitwarden_workflow_linter.rules.run_actionlint import (
+    RunActionlint,
+    install_actionlint_source,
+    check_actionlint,
+    install_actionlint,
+)
 
 yaml = YAML()
 
@@ -28,6 +34,148 @@ def test_rule_on_incorrect_workflow(rule):
     result, _ = rule.fn(incorrect_workflow)
     assert result is False
 
-def test_arguments(rule):
-    with pytest.raises(NotImplementedError):
-        rule.fn("./")
+
+def test_pass_install_actionlint_linux():
+    result, _ = install_actionlint("Linux")
+    assert result is True
+
+
+def test_install_actionlint_darwin(monkeypatch):
+    def mock_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    result, _ = install_actionlint("Darwin")
+    assert result is True
+
+
+def test_failed_install_actionlint_darwin(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "cmd")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    result, error = install_actionlint("Darwin")
+    assert result is False
+    assert "An error occurred" in error
+
+
+def test_install_actionlint_windows(monkeypatch):
+    def mock_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    result, _ = install_actionlint("Windows")
+    assert result is True
+
+
+def test_failed_install_actionlint_windows(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "cmd")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    result, error = install_actionlint("Windows")
+    assert result is False
+    assert "An error occurred" in error
+
+
+def test_install_actionlint_source(monkeypatch):
+    def mock_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    result, _ = install_actionlint_source("An error occurred")
+    assert result is True
+
+
+def test_failed_install_actionlint_source(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "cmd")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    result, error = install_actionlint_source("An error occurred")
+    assert result is False
+    assert "An error occurred" in error
+
+
+def test_check_actionlint_installed(monkeypatch):
+    def mock_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    result, _ = check_actionlint("Linux")
+    assert result is True
+
+
+def test_failed_check_actionlint_installed(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, "cmd")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    result, _ = check_actionlint("Linux")
+    assert result is False
+
+
+def test_check_actionlint_not_installed(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    result, _ = check_actionlint("Linux")
+    assert result is False
+
+
+def test_run_actionlint_installed(monkeypatch, rule):
+    def mock_check_actionlint(*args, **kwargs):
+        return True, "/mock/location"
+
+    def mock_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 0, stdout="")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.setattr(
+        "src.bitwarden_workflow_linter.rules.run_actionlint.check_actionlint",
+        mock_check_actionlint,
+    )
+
+    workflow = WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
+    result, _ = rule.fn(workflow)
+    assert result is True
+
+
+def test_run_actionlint_not_installed(monkeypatch, rule):
+    def mock_check_actionlint(*args, **kwargs):
+        return False, ""
+
+    monkeypatch.setattr(
+        "src.bitwarden_workflow_linter.rules.run_actionlint.check_actionlint",
+        mock_check_actionlint,
+    )
+
+    workflow = WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
+    result, error = rule.fn(workflow)
+    assert result is False
+    assert "Actionlint must pass" in error
+
+
+def test_run_actionlint_installed_error(monkeypatch, rule):
+    def mock_check_actionlint(*args, **kwargs):
+        return True, "/mock/location"
+
+    def mock_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args, 110, stdout="An error occurred")
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    monkeypatch.setattr(
+        "src.bitwarden_workflow_linter.rules.run_actionlint.check_actionlint",
+        mock_check_actionlint,
+    )
+
+    workflow = WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
+    result, error = rule.fn(workflow)
+    assert result is False
+    assert "An error occurred" in error

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -16,7 +16,7 @@ def fixture_rule():
 def test_rule_on_correct_workflow(rule):
     correct_workflow =  WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
     result, _ = rule.fn(correct_workflow)
-    assert result is True
+    assert result is False
 
 
 def test_rule_on_incorrect_workflow(rule):

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -1,0 +1,21 @@
+"""Test src/bitwarden_workflow_linter/rules/name_exists.py."""
+
+import pytest
+
+from ruamel.yaml import YAML
+
+from src.bitwarden_workflow_linter.load import WorkflowBuilder
+from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
+
+
+yaml = YAML()
+
+def test_rule_on_correct_workflow(rule, correct_workflow):
+    result, _ = rule.fn(correct_workflow)
+    assert result is True
+
+
+def test_rule_on_incorrect_workflow(rule, incorrect_workflow):
+    print(f"Workflow name: {incorrect_workflow.name}")
+    result, _ = rule.fn(incorrect_workflow)
+    assert result is False

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -10,96 +10,29 @@ from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
 yaml = YAML()
 
 
-@pytest.fixture(name="correct_workflow")
-def fixture_correct_workflow():
-    workflow = """\
----
-name: test
-on:
-  workflow_dispatch:
-  pull_request:
-
-jobs:
-  job-key:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test
-        run: echo test
-
-  call-workflow:
-    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
-
-  test-normal-action:
-    name: Download Latest
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - run: |
-          echo test
-
-  test-local-action:
-    name: Testing a local action call
-    runs-on: ubuntu-20.04
-    steps:
-      - name: local-action
-        uses: ./version-bump
-"""
-    return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
+# @pytest.fixture(name="correct_workflow")
+# def fixture_correct_workflow():
+#     workflow = "tests/fixtures/test_workflow.yaml"
+#     return WorkflowBuilder.build(workflow)
 
 
-@pytest.fixture(name="incorrect_workflow")
-def fixture_incorrect_workflow():
-    workflow = """\
----
-names: test
-on:
-  workflow_dispatch:
-  pull_request:
-
-jobs:
-  job-key:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test
-        run: echo test
-
-  call-workflow:
-    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
-
-  test-normal-action:
-    name: Download Latest
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - run: |
-          echo test
-
-  test-local-action:
-    name: Testing a local action call
-    runs-on: ubuntu-20.04
-    steps:
-      - name: local-action
-        uses: ./version-bump
-"""
-    return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
-
+# @pytest.fixture(name="incorrect_workflow")
+# def fixture_incorrect_workflow():
+#     workflow = "tests/fixtures/test_workflow_incorrect.yaml"
+#     return WorkflowBuilder.build(workflow)
 
 @pytest.fixture(name="rule")
 def fixture_rule():
     return RunActionlint()
 
 
-def test_rule_on_correct_workflow(rule, correct_workflow):
+def test_rule_on_correct_workflow(rule):
+    correct_workflow =  WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
     result, _ = rule.fn(correct_workflow)
     assert result is True
 
 
-def test_rule_on_incorrect_workflow(rule, incorrect_workflow):
+def test_rule_on_incorrect_workflow(rule):
+    incorrect_workflow = WorkflowBuilder.build("tests/fixtures/test_workflow_incorrect.yaml")
     result, _ = rule.fn(incorrect_workflow)
     assert result is False

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -27,3 +27,7 @@ def test_rule_on_incorrect_workflow(rule):
     )
     result, _ = rule.fn(incorrect_workflow)
     assert result is False
+
+def test_arguments(rule):
+    with pytest.raises(NotImplementedError):
+        rule.fn("./")

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -16,7 +16,7 @@ def fixture_rule():
 def test_rule_on_correct_workflow(rule):
     correct_workflow =  WorkflowBuilder.build("tests/fixtures/test_workflow.yaml")
     result, _ = rule.fn(correct_workflow)
-    assert result is False
+    assert result is True
 
 
 def test_rule_on_incorrect_workflow(rule):

--- a/tests/rules/test_run_actionlint.py
+++ b/tests/rules/test_run_actionlint.py
@@ -1,4 +1,4 @@
-"""Test src/bitwarden_workflow_linter/rules/name_exists.py."""
+"""Test src/bitwarden_workflow_linter/rules/run_actionlint."""
 
 import pytest
 
@@ -7,15 +7,96 @@ from ruamel.yaml import YAML
 from src.bitwarden_workflow_linter.load import WorkflowBuilder
 from src.bitwarden_workflow_linter.rules.run_actionlint import RunActionlint
 
-
 yaml = YAML()
+
+@pytest.fixture(name="correct_workflow")
+def fixture_correct_workflow():
+    workflow = """\
+---
+name: test
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  job-key:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo test
+
+  call-workflow:
+    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
+
+  test-normal-action:
+    name: Download Latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - run: |
+          echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump
+"""
+    return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
+
+
+
+@pytest.fixture(name="incorrect_workflow")
+def fixture_incorrect_workflow():
+    workflow = """\
+---
+names: test
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  job-key:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo test
+
+  call-workflow:
+    uses: bitwarden/server/.github/workflows/workflow-linter.yml@master
+
+  test-normal-action:
+    name: Download Latest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - run: |
+          echo test
+
+  test-local-action:
+    name: Testing a local action call
+    runs-on: ubuntu-20.04
+    steps:
+      - name: local-action
+        uses: ./version-bump
+"""
+    return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
+
+@pytest.fixture(name="rule")
+def fixture_rule():
+    return RunActionlint()
 
 def test_rule_on_correct_workflow(rule, correct_workflow):
     result, _ = rule.fn(correct_workflow)
     assert result is True
 
-
-def test_rule_on_incorrect_workflow(rule, incorrect_workflow):
-    print(f"Workflow name: {incorrect_workflow.name}")
+def test_rule_on_correct_workflow(rule, incorrect_workflow):
     result, _ = rule.fn(incorrect_workflow)
     assert result is False

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -72,7 +72,7 @@ jobs:
 
 
 def test_simple_workflow(simple_workflow_yaml):
-    workflow = Workflow.init("", simple_workflow_yaml)
+    workflow = Workflow.init("", None, simple_workflow_yaml)
 
     assert workflow.name == "test"
     assert len(workflow.on.keys()) == 1
@@ -80,7 +80,7 @@ def test_simple_workflow(simple_workflow_yaml):
 
 
 def test_complex_workflow(complex_workflow_yaml):
-    workflow = Workflow.init("", complex_workflow_yaml)
+    workflow = Workflow.init("", None, complex_workflow_yaml)
 
     assert workflow.name == "test"
     assert len(workflow.on.keys()) == 2
@@ -91,7 +91,7 @@ def test_workflow_extra_kwargs(simple_workflow_yaml):
     extra_data_workflow = simple_workflow_yaml
     extra_data_workflow["extra"] = "This should not exist"
 
-    workflow = Workflow.init("", extra_data_workflow)
+    workflow = Workflow.init("", None, extra_data_workflow)
 
     with pytest.raises(Exception):
         assert workflow.extra == "test"


### PR DESCRIPTION
## 🎟️ Tracking

From [BRE-469](https://bitwarden.atlassian.net/browse/BRE-469)

## 📔 Objective

Workflow Linter V2 is meant to run alongside Actionlint, so it makes sure to run Actionlint as a part of the default workflow linter run.

Enabled for Workflow-linter workflows only so far.  Other repositories with settings override will need the job added to their settings.yaml file

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-469]: https://bitwarden.atlassian.net/browse/BRE-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ