### PR TITLE
[BRE-541] Handling steps where no comment is added to uses

### DIFF
--- a/src/bitwarden_workflow_linter/models/step.py
+++ b/src/bitwarden_workflow_linter/models/step.py
@@ -39,10 +39,13 @@ class Step:
         new_step.key = idx
         new_step.job = job
 
-        if "uses" in data.ca.items and data.ca.items["uses"][2]:
-            new_step.uses_comment = data.ca.items["uses"][2].value.replace("\n", "")
+        if new_step.uses:
+            if "uses" in data.ca.items and data.ca.items["uses"][2]:
+                new_step.uses_comment = data.ca.items["uses"][2].value.replace("\n", "")
+                new_step.uses_version = new_step.uses_comment.split(" ")[-1]
             if "@" in new_step.uses:
                 new_step.uses_path, new_step.uses_ref = new_step.uses.split("@")
-                new_step.uses_version = new_step.uses_comment.split(" ")[-1]
+            else:
+                new_step.uses_path = new_step.uses
 
         return new_step

--- a/tests/rules/test_step_approved.py
+++ b/tests/rules/test_step_approved.py
@@ -70,6 +70,11 @@ jobs:
       - name: Checkout Branch
         uses: joseph-flinn/action-DNE@main
 
+      - name: Checkout Branch with Ref
+        uses: notbitwarden/action-DNE@main
+        with:
+            ref: main
+
 """
     return WorkflowBuilder.build(workflow=yaml.load(workflow), from_file=False)
 
@@ -95,6 +100,10 @@ def test_rule_on_correct_workflow(rule, correct_workflow):
 
 def test_rule_on_incorrect_workflow(rule, incorrect_workflow):
     result, message = rule.fn(incorrect_workflow.jobs["job-key"].steps[0])
+    assert result is False
+    assert "New Action detected" in message
+
+    result, message = rule.fn(incorrect_workflow.jobs["job-key"].steps[1])
     assert result is False
     assert "New Action detected" in message
 

--- a/tests/rules/test_step_approved.py
+++ b/tests/rules/test_step_approved.py
@@ -71,7 +71,7 @@ jobs:
         uses: joseph-flinn/action-DNE@main
 
       - name: Checkout Branch with Ref
-        uses: notbitwarden/action-DNE@main
+        uses: notbitwarden/subfolder/action-DNE@main
         with:
             ref: main
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -36,6 +36,45 @@ with:
     return Step.init(0, "default", step_yaml)
 
 
+@pytest.fixture(name="uses_step_no_comments")
+def fixture_uses_step_no_comments():
+    step_str = """\
+name: Download Artifacts
+uses: bitwarden/download-artifacts@main
+with:
+    workflow: upload-test-artifacts.yml
+    artifacts: artifact
+    path: artifact
+    branch: main
+
+"""
+    yaml = YAML()
+    step_yaml = yaml.load(step_str)
+    return Step.init(0, "default", step_yaml)
+
+
+@pytest.fixture(name="uses_step_no_ref")
+def fixture_uses_step_no_ref():
+    step_str = """\
+name: Run Local Workflow
+uses: ./.github/workflows/_local.yml
+"""
+    yaml = YAML()
+    step_yaml = yaml.load(step_str)
+    return Step.init(0, "default", step_yaml)
+
+
+@pytest.fixture(name="uses_step_no_ref_with_comments")
+def fixture_uses_step_no_ref_with_comments():
+    step_str = """\
+name: Run Local Workflow
+uses: ./.github/workflows/_local.yml # A comment
+"""
+    yaml = YAML()
+    step_yaml = yaml.load(step_str)
+    return Step.init(0, "default", step_yaml)
+
+
 def test_step_default(default_step):
     assert default_step.key == 0
     assert default_step.job == "default"
@@ -74,5 +113,32 @@ def test_step_keyword_field(uses_step):
 def test_step_comment(uses_step):
     assert uses_step.key == 0
     assert uses_step.job == "default"
-    assert uses_step.uses_comment is not None
+    assert uses_step.uses_ref == "main"
+    assert uses_step.uses_version == "v1.0.0"
     assert uses_step.uses_comment == "# v1.0.0"
+
+
+def test_step_no_comments(uses_step_no_comments):
+    assert uses_step_no_comments.key == 0
+    assert uses_step_no_comments.job == "default"
+    assert uses_step_no_comments.uses_ref == "main"
+    assert uses_step_no_comments.uses_version is None
+    assert uses_step_no_comments.uses_comment is None
+
+
+def test_step_no_ref(uses_step_no_ref):
+    assert uses_step_no_ref.key == 0
+    assert uses_step_no_ref.job == "default"
+    assert uses_step_no_ref.uses_ref is None
+    assert uses_step_no_ref.uses_version is None
+    assert uses_step_no_ref.uses_comment is None
+
+
+def test_step_no_ref_with_comments(uses_step_no_ref_with_comments):
+    assert uses_step_no_ref_with_comments.key == 0
+    assert uses_step_no_ref_with_comments.job == "default"
+    assert uses_step_no_ref_with_comments.uses_ref is None
+    assert (
+        uses_step_no_ref_with_comments.uses_version == "comment"
+    )  # We are not currently validating the version matches a specific format
+    assert uses_step_no_ref_with_comments.uses_comment == "# A comment"


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-541](https://bitwarden.atlassian.net/browse/BRE-541)

## 📔 Objective

Fixes an issue where the linter was throwing an exception if comments didn't exist in the `uses` section of a step.  Now it correctly reports an error to the users to comment the version of the action.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-541]: https://bitwarden.atlassian.net/browse/BRE-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ