### PR TITLE
Added gradle/wrapper-validation-action v3.5.0

### DIFF
--- a/src/bitwarden_workflow_linter/default_actions.json
+++ b/src/bitwarden_workflow_linter/default_actions.json
@@ -269,6 +269,11 @@
     "sha": "cc4fc85e6b35bafd578d5ffbc76a5518407e1af0",
     "version": "v4.2.1"
   },
+  "gradle/wrapper-validation-action": {
+    "name": "gradle/wrapper-validation-action",
+    "sha": "f9c9c575b8b21b6485636a91ffecd10e558c62f6",
+    "version": "v3.5.0"
+  },
   "hashicorp/setup-packer": {
     "name": "hashicorp/setup-packer",
     "sha": "1aa358be5cf73883762b302a3a03abd66e75b232",


### PR DESCRIPTION
## 🎟️ Tracking

Pre-requisite for https://bitwarden.atlassian.net/browse/VULN-126

## 📔 Objective

When trying to update the Sonarqube configuration, a lint test was failing due to bwwl not having this gradle action. This should be the pre-requisite for https://github.com/bitwarden/passwordless-android/pull/106 to lint properly

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
