### PR TITLE
removing test notes

### DIFF
--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -11,15 +11,16 @@ from ..models.workflow import Workflow
 from ..utils import LintLevels, Settings
 
 
-def install_actionlint(platform_system: str) -> Tuple[bool, str]:
+def install_actionlint(platform_system: str, version: Optional[str] = None) -> Tuple[bool, str]:
     """If actionlint is not installed, detects OS platform
     and installs actionlint"""
 
     error = f"An error occurred when installing Actionlint on {platform_system}"
 
     if platform_system.startswith("Linux"):
-        return install_actionlint_source(error)
+        return install_actionlint_source(error, version)
     elif platform_system == "Darwin":
+        return install_actionlint_source(error, version)
         try:
             subprocess.run(["brew", "install", "actionlint"], check=True)
             return True, ""
@@ -34,7 +35,7 @@ def install_actionlint(platform_system: str) -> Tuple[bool, str]:
     return False, error
 
 
-def install_actionlint_source(error) -> Tuple[bool, str]:
+def install_actionlint_source(error, settings = None) -> Tuple[bool, str]:
     """Install Actionlint Binary from provided script"""
     url = "https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash"
     version = "1.6.17"
@@ -67,7 +68,6 @@ please check your package installer or manually install it",
     except FileNotFoundError:
         return install_actionlint(platform_system)
 
-
 class RunActionlint(Rule):
     """Rule to run actionlint as part of workflow linter V2."""
 
@@ -83,7 +83,7 @@ class RunActionlint(Rule):
                 "Running actionlint without a filename is not currently supported"
             )
 
-        installed, location = check_actionlint(platform.system())
+        installed, location = check_actionlint(platform.system(), settings.actionlint_version)
         if installed:
             if location:
                 result = subprocess.run(

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -83,7 +83,7 @@ class RunActionlint(Rule):
                 "Running actionlint without a filename is not currently supported"
             )
 
-        installed, location = check_actionlint(platform.system(), settings.actionlint_version)
+        installed, location = check_actionlint(platform.system())
         if installed:
             if location:
                 result = subprocess.run(


### PR DESCRIPTION
## 🎟️ Tracking

While working on another ticket I noticed some debugging notes were left in the run_actionlint rule, this PR removes them 
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
