### PR TITLE
[BRE-621] fixing actionlint

### DIFF
--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -65,7 +65,17 @@ def check_actionlint(platform_system: str) -> Tuple[bool, str]:
 please check your package installer or manually install it",
         )
     except FileNotFoundError:
-        return install_actionlint(platform_system)
+        is_local = subprocess.run(
+                    ["ls | grep '^actionlint'"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    shell=True
+                )
+        if is_local.stdout:
+            return True, "."
+        else:
+            return install_actionlint(platform_system)
 
 
 class RunActionlint(Rule):
@@ -97,7 +107,7 @@ class RunActionlint(Rule):
                     ["actionlint", obj.filename],
                     capture_output=True,
                     text=True,
-                    check=False,
+                    check=False
                 )
             if result.returncode == 1:
                 return False, result.stdout

--- a/src/bitwarden_workflow_linter/rules/run_actionlint.py
+++ b/src/bitwarden_workflow_linter/rules/run_actionlint.py
@@ -107,7 +107,7 @@ class RunActionlint(Rule):
                     ["actionlint", obj.filename],
                     capture_output=True,
                     text=True,
-                    check=False
+                    check=False,
                 )
             if result.returncode == 1:
                 return False, result.stdout


### PR DESCRIPTION
## 🎟️ Tracking

Workflow linter was installing actionlint repeatedly, once per linter rule.  This bypasses installing from source to the local directory if it was done already in a previous step, without giving the script permission to modify the host's PATH

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
