### PR TITLE
Bre 551 require workflow permissions activate - warning only

### DIFF
--- a/.github/workflows/examples/example.yaml
+++ b/.github/workflows/examples/example.yaml
@@ -6,95 +6,107 @@
 
 name: Build
 
-on:  # Describes when to run the workflow
-  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+permissions:
+    read-all # Sets permissions of the GITHUB_TOKEN
+    # More info: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
 
-  workflow_dispatch:  # When triggered manually
+on: # Describes when to run the workflow
+    # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 
-  push:  # On push to the following branches. Temporarily add a development branch to prompt workflow runs for troubleshooting
-    branches: ["main", "rc", "hotfix-rc"]
-    paths-ignore:  # Updates to these directories or files will not trigger a workflow run
-      - ".github/workflows/**"
+    workflow_dispatch: # When triggered manually
 
-  # Pull_request_target:  #We strongly discourage using this unless absolutely necessary as it requires access to certain Github secrets.
-  # If using this, include the .github/workflows/check-run.yml job and target only the main branch
-  # More info at https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
+    push: # On push to the following branches. Temporarily add a development branch to prompt workflow runs for troubleshooting
+        branches: ["main", "rc", "hotfix-rc"]
+        paths-ignore: # Updates to these directories or files will not trigger a workflow run
+            - ".github/workflows/**"
 
-  pull_request:  # When a pull request event occurs
-    types: [opened, synchronize, unlabeled, labeled, unlabeled, reopened, edited]
-    branches: ["main"]  # Branches where a pull request will trigger the workflow
+    # Pull_request_target:  #We strongly discourage using this unless absolutely necessary as it requires access to certain Github secrets.
+    # If using this, include the .github/workflows/check-run.yml job and target only the main branch
+    # More info at https://github.blog/news-insights/product-news/github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks
 
+    pull_request: # When a pull request event occurs
+        types:
+            [
+                opened,
+                synchronize,
+                unlabeled,
+                labeled,
+                unlabeled,
+                reopened,
+                edited,
+            ]
+        branches: ["main"] # Branches where a pull request will trigger the workflow
 
-  release:  # Runs your workflow when release activity in your repository occurs
-    types: [published, created]
+    release: # Runs your workflow when release activity in your repository occurs
+        types: [published, created]
 
-  merge_group:  # Runs required status checks on merge groups created by merge queue
-    types: [checks_requested]
+    merge_group: # Runs required status checks on merge groups created by merge queue
+        types: [checks_requested]
 
-  repository_dispatch:  # Runs when a webook event triggers a workflow from outside of github
-    types: [contentful-publish]  # Optional, limit repository dispatch events to those in a specified list
+    repository_dispatch: # Runs when a webook event triggers a workflow from outside of github
+        types: [contentful-publish] # Optional, limit repository dispatch events to those in a specified list
 
-  workflow_call:  # Workflow can be called by another workflow
+    workflow_call: # Workflow can be called by another workflow
 
-env:  # Environment variables set for this step but not accessible by all workflows, steps or jobs.
-  _AZ_REGISTRY: "ACMEprod.azurecr.io"
-  INCREMENTAL: "${{ contains(github.event_name, 'pull_request') && '--sast-incremental' || '' }}"
+env: # Environment variables set for this step but not accessible by all workflows, steps or jobs.
+    _AZ_REGISTRY: "ACMEprod.azurecr.io"
+    INCREMENTAL: "${{ contains(github.event_name, 'pull_request') && '--sast-incremental' || '' }}"
 
-jobs:  # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-  first-job:
-    name: First Job Name
-    uses: ./.github/workflows/examples/example-references/_version.yml  # Path to an existing github action
-    if: github.event.pull_request.draft == false  # prevent part of a job from running on a draft PR
-    secrets: inherit  # When called by another workflow, pass all the calling workflow's secrets to the called workflow
-    # "secrets" is only available for a reusable workflow call with "uses"
-    strategy:  # Create multiple job runs for each of a set of variables
-      fail-fast: false  # If true, cancel entire run if any job in the matrix fails
-      matrix:  # Matrix of variables used to define multiple job runs
-        include:
-          - project_name: Admin
-            base_path: ./src
-            node: true  # Enables steps with if: ${{ matrix.node }}
+jobs: # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+    first-job:
+        name: First Job Name
+        uses: ./.github/workflows/examples/example-references/_version.yml # Path to an existing github action
+        if: github.event.pull_request.draft == false # prevent part of a job from running on a draft PR
+        secrets: inherit # When called by another workflow, pass all the calling workflow's secrets to the called workflow
+        # "secrets" is only available for a reusable workflow call with "uses"
+        strategy: # Create multiple job runs for each of a set of variables
+            fail-fast: false # If true, cancel entire run if any job in the matrix fails
+            matrix: # Matrix of variables used to define multiple job runs
+                include:
+                    - project_name: Admin
+                      base_path: ./src
+                      node: true # Enables steps with if: ${{ matrix.node }}
 
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
-    permissions:  # Sets permissions of the GITHUB_TOKEN
-      security-events: write  # Allow actions to upload results to Github
-      id-token: write  # Required to fetch an OpenID Connect (OIDC) token
-      contents: read  # For actions/checkout to fetch code
-      deployments: write  # Permits an action to create a new deployment
-      issues: write  # Permits an action to create a new issue
-      checks: write  # Permits an action to create a check run
-      actions: write  # Permits an action to cancel a workflow run
-      packages: read  # Permits an action to access packages on GitHub Packages
-      pull-requests: write  # Permits an action to add a label to a pull request
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+        permissions: # Sets permissions of the GITHUB_TOKEN
+            security-events: write # Allow actions to upload results to Github
+            id-token: write # Required to fetch an OpenID Connect (OIDC) token
+            contents: read # For actions/checkout to fetch code
+            deployments: write # Permits an action to create a new deployment
+            issues: write # Permits an action to create a new issue
+            checks: write # Permits an action to create a check run
+            actions: write # Permits an action to cancel a workflow run
+            packages: read # Permits an action to access packages on GitHub Packages
+            pull-requests: write # Permits an action to add a label to a pull request
 
-  # steps: when a reusable workflow is called with "uses", "steps" is not available
-  second-job:
-    name: Second Job Name
-    runs-on: ubuntu-22.04  # The type of runner that the job will run on, not available if "uses" is used
-    defaults:
-      run:  # Set the default shell and working directory
-        shell: bash
-        working-directory: "home/WorkingDirectory"
+    # steps: when a reusable workflow is called with "uses", "steps" is not available
+    second-job:
+        name: Second Job Name
+        runs-on: ubuntu-22.04 # The type of runner that the job will run on, not available if "uses" is used
+        defaults:
+            run: # Set the default shell and working directory
+                shell: bash
+                working-directory: "home/WorkingDirectory"
 
-    needs:
-      - first-job  # This job will wait until first-job completes
-    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/setting-a-default-shell-and-working-directory
-    steps:
-      - name: Descriptive step name
-        # NOT RECOMMENDED if: always()  # run even if previous steps failed or the workflow is canceled, this can cause a workflow run to hang indefinitely
-        if: failure()  # run when any previous step of a job fails
-        # if: '!cancelled()'  # run even if previous steps failed
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2 Always pin a public action version to a full git SHA, followed by the version number in a comment.  Version pins are insecure and can introduce vulnerabilities into workflows.
-        with:  # Parameters specific to this action that need to be defined in order for the step to be completed
-          fetch-depth: 0  # Full git history for actions that rely on whether a change has occurred
-          ref: ${{ github.event.pull_request.head.sha }}
-          creds: ${{ secrets.SECRETS_OR_CREDENTIALS }}
-      - name: Another descriptive step name
-        # Run a script instead of an existing github action
-        run: |
-          whoami
-          dotnet --info
-          node --version
-          npm --version
-          echo "GitHub ref: $GITHUB_REF"
-          echo "GitHub event: $GITHUB_EVENT"
+        needs:
+            - first-job # This job will wait until first-job completes
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/setting-a-default-shell-and-working-directory
+        steps:
+            - name: Descriptive step name
+              # NOT RECOMMENDED if: always()  # run even if previous steps failed or the workflow is canceled, this can cause a workflow run to hang indefinitely
+              if: failure() # run when any previous step of a job fails
+              # if: '!cancelled()'  # run even if previous steps failed
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 Always pin a public action version to a full git SHA, followed by the version number in a comment.  Version pins are insecure and can introduce vulnerabilities into workflows.
+              with: # Parameters specific to this action that need to be defined in order for the step to be completed
+                  fetch-depth: 0 # Full git history for actions that rely on whether a change has occurred
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  creds: ${{ secrets.SECRETS_OR_CREDENTIALS }}
+            - name: Another descriptive step name
+              # Run a script instead of an existing github action
+              run: |
+                  whoami
+                  dotnet --info
+                  node --version
+                  npm --version
+                  echo "GitHub ref: $GITHUB_REF"
+                  echo "GitHub event: $GITHUB_EVENT"

--- a/.github/workflows/examples/scan.yaml
+++ b/.github/workflows/examples/scan.yaml
@@ -7,120 +7,125 @@
 
 name: Scan
 
+permissions:
+    read-all # Sets permissions of the GITHUB_TOKEN
+    # More info: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
+
 on:
-  # Controls when the workflow will run
+    # Controls when the workflow will run
 
-  # Can use other triggers such as multiple events, activity types and fiters:
-  # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#on
-  workflow_dispatch:  # When triggered manually
+    # Can use other triggers such as multiple events, activity types and fiters:
+    # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#on
+    workflow_dispatch: # When triggered manually
 
-  push:
-    # On push to the following branches.  Temporarily add a development
-    # branch to prompt workflow runs for troubleshooting
-    branches:
-      - "main"
-      - "rc"
-      - "hotfix-rc"
-  pull_request_target:
-    # When a pull request event occurs. Default is opened or reopened unless
-    # otherwise specified, as below:
-    types: [opened, synchronize]  # Options include labeled, unlabeled, reopened
-    branches: 'main'
+    push:
+        # On push to the following branches.  Temporarily add a development
+        # branch to prompt workflow runs for troubleshooting
+        branches:
+            - "main"
+            - "rc"
+            - "hotfix-rc"
+    pull_request_target:
+        # When a pull request event occurs. Default is opened or reopened unless
+        # otherwise specified, as below:
+        types: [opened, synchronize] # Options include labeled, unlabeled, reopened
+        branches: "main"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in
 # parallel
 jobs:
-  # This workflow contains the jobs "check-run", "sast", and "quality"
-  # This job is relatively simple and just imports a previously written action
-  # to be used in this workflow
-  check-run:  # You set this value with the name of the job you're describing
-    name: Check PR run  # Human readable descriptor
-    # location and branch of bitwarden-owned action being used
-    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+    # This workflow contains the jobs "check-run", "sast", and "quality"
+    # This job is relatively simple and just imports a previously written action
+    # to be used in this workflow
+    check-run: # You set this value with the name of the job you're describing
+        name: Check PR run # Human readable descriptor
+        # location and branch of bitwarden-owned action being used
+        uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
 
-  sast:
-    # A more complex job that has multiple actions as steps described below
-    name: SAST scan
-    runs-on: ubuntu-22.04  # The type of runner that the job will run on
-    needs: check-run  # This job will wait until check-run completes
-    permissions:  # Sets permissions of the GITHUB_TOKEN
-      contents: read  # For actions/checkout to fetch code
-      pull-requests: write  # For github actions to upload feedback to PR
-      # For github/codeql-action/upload-sarif to upload SARIF results
-      security-events: write
+    sast:
+        # A more complex job that has multiple actions as steps described below
+        name: SAST scan
+        runs-on: ubuntu-22.04 # The type of runner that the job will run on
+        needs: check-run # This job will wait until check-run completes
+        permissions: # Sets permissions of the GITHUB_TOKEN
+            contents: read # For actions/checkout to fetch code
+            pull-requests: write # For github actions to upload feedback to PR
+            # For github/codeql-action/upload-sarif to upload SARIF results
+            security-events: write
 
-    # Steps represent a sequence of tasks executed as part of the job
-    steps:
-      - name: Check out repo
-        # Always pin a public action version to a full git SHA.
-        # Version pins are insecure and can introduce vulnerabilities
-        # into workflows.
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          # Parameters specific to this action that need to be defined
-          # in order for the step to be completed
-          ref: ${{  github.event.pull_request.head.sha }}
+        # Steps represent a sequence of tasks executed as part of the job
+        steps:
+            - name: Check out repo
+              # Always pin a public action version to a full git SHA.
+              # Version pins are insecure and can introduce vulnerabilities
+              # into workflows.
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  # Parameters specific to this action that need to be defined
+                  # in order for the step to be completed
+                  ref: ${{  github.event.pull_request.head.sha }}
 
-      - name: Scan with Checkmarx
-        if: github.event.pull_request.draft == false  # Prevent step from running on draft PR
-        uses: checkmarx/ast-github-action@f0869bd1a37fddc06499a096101e6c900e815d81  # 2.0.36
-        # Environment variables set for this step but not accessible by all
-        # workflows, steps or jobs
-        env:
-          INCREMENTAL: "${{ contains(github.event_name, 'pull_request') \
-          && '--sast-incremental' || '' }}"
-        with:
-          project_name: ${{ github.repository }}
-          cx_tenant: ${{ secrets.CHECKMARX_TENANT }}
-          base_uri: https://ast.checkmarx.net/
-          cx_client_id: ${{ secrets.CHECKMARX_CLIENT_ID }}
-          cx_client_secret: ${{ secrets.CHECKMARX_SECRET }}
-          additional_params: |
-            --report-format sarif \
-            --filter \
-            "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT"\
-            --output-path . ${{ env.INCREMENTAL }}
+            - name: Scan with Checkmarx
+              if: github.event.pull_request.draft == false # Prevent step from running on draft PR
+              uses: checkmarx/ast-github-action@f0869bd1a37fddc06499a096101e6c900e815d81 # 2.0.36
+              # Environment variables set for this step but not accessible by all
+              # workflows, steps or jobs
+              env:
+                  INCREMENTAL:
+                      "${{ contains(github.event_name, 'pull_request') \
+                      && '--sast-incremental' || '' }}"
+              with:
+                  project_name: ${{ github.repository }}
+                  cx_tenant: ${{ secrets.CHECKMARX_TENANT }}
+                  base_uri: https://ast.checkmarx.net/
+                  cx_client_id: ${{ secrets.CHECKMARX_CLIENT_ID }}
+                  cx_client_secret: ${{ secrets.CHECKMARX_SECRET }}
+                  additional_params: |
+                      --report-format sarif \
+                      --filter \
+                      "state=TO_VERIFY;PROPOSED_NOT_EXPLOITABLE;CONFIRMED;URGENT"\
+                      --output-path . ${{ env.INCREMENTAL }}
 
-      - name: Upload Checkmarx results to GitHub
-        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd  # v3.27.0
-        with:
-          sarif_file: cx_result.sarif
+            - name: Upload Checkmarx results to GitHub
+              uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
+              with:
+                  sarif_file: cx_result.sarif
 
-  quality:
-    name: Quality scan
-    runs-on: ubuntu-22.04
-    needs: check-run
-    permissions:
-      contents: read
-      pull-requests: write
+    quality:
+        name: Quality scan
+        runs-on: ubuntu-22.04
+        needs: check-run
+        permissions:
+            contents: read
+            pull-requests: write
 
-    steps:
-      # Set up whatever resources your environment will need
-      # to run workflows on your code
-      - name: Set up JDK 17
-        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b  # v4.5.0
-        with:
-          java-version: 17
-          distribution: "zulu"
-      # This step checks out a copy of your repository
-      - name: Set up .NET
-        uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25  # v4.1.0
-      # Install a tool without a Github Action
-      - name: Install SonarCloud scanner
-        run: dotnet tool install dotnet-sonarscanner -g
+        steps:
+            # Set up whatever resources your environment will need
+            # to run workflows on your code
+            - name: Set up JDK 17
+              uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
+              with:
+                  java-version: 17
+                  distribution: "zulu"
+            # This step checks out a copy of your repository
+            - name: Set up .NET
+              uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+            # Install a tool without a Github Action
+            - name: Install SonarCloud scanner
+              run: dotnet tool install dotnet-sonarscanner -g
 
-      - name: Scan with SonarCloud
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Additional scripts to run outside of a Github Action
-        run: |
-          dotnet-sonarscanner begin /k:" \
-          ${{ github.repository_owner }}_${{ github.event.repository.name }}" \
-          /d:sonar.test.inclusions=test/,bitwarden_license/test/ \
-          /d:sonar.exclusions=test/,bitwarden_license/test/ \
-          /o:"${{ github.repository_owner }}" \
-          /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
-          /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build
-          dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+            - name: Scan with SonarCloud
+              env:
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              # Additional scripts to run outside of a Github Action
+              run: |
+                  dotnet-sonarscanner begin /k:" \
+                  ${{ github.repository_owner }}_${{ github.event.repository.name }}" \
+                  /d:sonar.test.inclusions=test/,bitwarden_license/test/ \
+                  /d:sonar.exclusions=test/,bitwarden_license/test/ \
+                  /o:"${{ github.repository_owner }}" \
+                  /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
+                  /d:sonar.host.url="https://sonarcloud.io"
+                  dotnet build
+                  dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/settings.yaml
+++ b/settings.yaml
@@ -17,8 +17,7 @@ enabled_rules:
       level: warning
     - id: bitwarden_workflow_linter.rules.check_pr_target.RuleCheckPrTarget
       level: warning
-    # Cannot add this in until the rule functionality is merged through to main
-    # - id: bitwarden_workflow_linter.rules.permissions_exist.RulePermissionsExist
-    #   level: warning
+    - id: bitwarden_workflow_linter.rules.permissions_exist.RulePermissionsExist
+      level: warning
 
 approved_actions_path: default_actions.json

--- a/src/bitwarden_workflow_linter/default_settings.yaml
+++ b/src/bitwarden_workflow_linter/default_settings.yaml
@@ -17,8 +17,7 @@ enabled_rules:
       level: warning
     - id: bitwarden_workflow_linter.rules.check_pr_target.RuleCheckPrTarget
       level: warning
-    # Cannot add this in until the rule functionality is merged through to main
-    # - id: bitwarden_workflow_linter.rules.permissions_exist.RulePermissionsExist
-    #   level: warning
+    - id: bitwarden_workflow_linter.rules.permissions_exist.RulePermissionsExist
+      level: warning
 
 approved_actions_path: default_actions.json


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-551](https://bitwarden.atlassian.net/browse/BRE-551)

## 📔 Objective

Follow up to [PR-81](https://github.com/bitwarden/workflow-linter/pull/81)
This activates the permissions required rule (As a warning for now)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-551]: https://bitwarden.atlassian.net/browse/BRE-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ