### PR TITLE
BRE-609/check-pr-target-rule-update

### DIFF
--- a/.github/workflows/examples/ci.yaml
+++ b/.github/workflows/examples/ci.yaml
@@ -10,6 +10,8 @@ on:
   pull_request:  # When a pull request event occurs
 
 permissions:  # Sets permissions of the GITHUB_TOKEN
+  contents: read
+  packages: read
   checks: write  # Permits an action to create a check run
   contents: read  # For actions to fetch code and list commits
   id-token: write  # Required to fetch an OpenID Connect (OIDC) token

--- a/.github/workflows/examples/ci.yaml
+++ b/.github/workflows/examples/ci.yaml
@@ -10,10 +10,9 @@ on:
   pull_request:  # When a pull request event occurs
 
 permissions:  # Sets permissions of the GITHUB_TOKEN
-  contents: read
-  packages: read
   checks: write  # Permits an action to create a check run
   contents: read  # For actions to fetch code and list commits
+  packages: read  # For actions to fetch packages
   id-token: write  # Required to fetch an OpenID Connect (OIDC) token
   pull-requests: write  # Permits an action to add a label to a pull request
 

--- a/.github/workflows/examples/ci.yaml
+++ b/.github/workflows/examples/ci.yaml
@@ -6,6 +6,7 @@ name: CI
 
 on:
   workflow_dispatch:  # Allows you to run this workflow manually from the Actions tab
+  workflow_call: # Allows this workflow to be called from another workflow
   pull_request:  # When a pull request event occurs
 
 permissions:  # Sets permissions of the GITHUB_TOKEN

--- a/.github/workflows/examples/pull_request_target.yml
+++ b/.github/workflows/examples/pull_request_target.yml
@@ -8,6 +8,7 @@ name: Build Thing on PR Target
 
 permissions:
   checks: read 
+  contents: read
 
 on:
   pull_request_target:

--- a/.github/workflows/examples/pull_request_target.yml
+++ b/.github/workflows/examples/pull_request_target.yml
@@ -1,0 +1,29 @@
+# This workflow is intended to be run when we need to build the client and produce artifacts that require secrets
+# when the PR source branch does not have access to secrets (e.g. a fork).
+# This workflow will run in the context of the target of the PR and have access to secrets.
+# This should only be done after reviewing the PR to ensure that no malicious code has been introduced,
+# as it could allow the code on the forked branch to have access to workflow secrets.
+
+name: Build Thing on PR Target
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check-run:
+    name: Check PR run
+    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
+
+  run-workflow:
+    name: Build Thing
+    needs: check-run
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    uses: ./.github/workflows/examples/ci.yaml
+    secrets: inherit

--- a/.github/workflows/examples/pull_request_target.yml
+++ b/.github/workflows/examples/pull_request_target.yml
@@ -6,6 +6,9 @@
 
 name: Build Thing on PR Target
 
+permissions:
+  checks: read 
+
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/settings.yaml
+++ b/settings.yaml
@@ -21,3 +21,4 @@ enabled_rules:
       level: warning
 
 approved_actions_path: default_actions.json
+default_branch: main

--- a/src/bitwarden_workflow_linter/default_settings.yaml
+++ b/src/bitwarden_workflow_linter/default_settings.yaml
@@ -21,3 +21,4 @@ enabled_rules:
       level: warning
 
 approved_actions_path: default_actions.json
+default_branch: main

--- a/src/bitwarden_workflow_linter/rules/check_pr_target.py
+++ b/src/bitwarden_workflow_linter/rules/check_pr_target.py
@@ -28,11 +28,11 @@ class RuleCheckPrTarget(Rule):
         self.settings = settings
 
     def targets_main_branch(self, obj: Workflow) -> bool:
-        default_branch = self.settings.default_branch if self.settings else "main"
+        default_branch = self.settings.default_branch
         branches = obj.on["pull_request_target"].get("branches", [])
         if isinstance(branches, str):
             branches = [branches]
-        return branches == [default_branch]
+        return len(branches) == 1 and branches[0] == default_branch
 
     def has_check_run(self, obj: Workflow) -> Tuple[bool, str]:
         for name, job in obj.jobs.items():

--- a/src/bitwarden_workflow_linter/rules/check_pr_target.py
+++ b/src/bitwarden_workflow_linter/rules/check_pr_target.py
@@ -27,16 +27,12 @@ class RuleCheckPrTarget(Rule):
         self.compatibility = [Workflow]
         self.settings = settings
 
-    def targets_main_branch(self, obj:Workflow) -> bool:
-        if obj.on["pull_request_target"].get("branches"):
-            branches_list = obj.on["pull_request_target"].get("branches")
-            if isinstance(branches_list, str):
-                branches_list = [branches_list]
-            if any(branch != 'main' for branch in branches_list):
-                return False
-        else:
-            return False
-        return True
+    def targets_main_branch(self, obj: Workflow) -> bool:
+        default_branch = self.settings.default_branch if self.settings else "main"
+        branches = obj.on["pull_request_target"].get("branches", [])
+        if isinstance(branches, str):
+            branches = [branches]
+        return branches == [default_branch]
 
     def has_check_run(self, obj: Workflow) -> Tuple[bool, str]:
         for name, job in obj.jobs.items():

--- a/src/bitwarden_workflow_linter/utils.py
+++ b/src/bitwarden_workflow_linter/utils.py
@@ -113,7 +113,7 @@ class Settings:
     enabled_rules: list[dict[str, str]]
     approved_actions: dict[str, Action]
     actionlint_version: str
-    default_branch: str
+    default_branch: Optional[str]
 
     def __init__(
         self,

--- a/src/bitwarden_workflow_linter/utils.py
+++ b/src/bitwarden_workflow_linter/utils.py
@@ -120,7 +120,7 @@ class Settings:
         enabled_rules: Optional[list[dict[str, str]]] = None,
         approved_actions: Optional[dict[str, dict[str, str]]] = None,
         actionlint_version: Optional[str] = None,
-        default_branch: [str] = "main",
+        default_branch: str = "main",
     ) -> None:
         """Settings object that can be overridden in settings.py.
 

--- a/src/bitwarden_workflow_linter/utils.py
+++ b/src/bitwarden_workflow_linter/utils.py
@@ -120,7 +120,7 @@ class Settings:
         enabled_rules: Optional[list[dict[str, str]]] = None,
         approved_actions: Optional[dict[str, dict[str, str]]] = None,
         actionlint_version: Optional[str] = None,
-        default_branch: str = "main",
+        default_branch: str = None,
     ) -> None:
         """Settings object that can be overridden in settings.py.
 
@@ -192,7 +192,9 @@ class Settings:
             ) as action_file:
                 settings["approved_actions"] = json.load(action_file)
 
-        default_branch = settings.get("default_branch", "main")        
+        default_branch = settings.get("default_branch")
+        if default_branch is None or len(default_branch) == 0:
+            raise Exception("The default_branch is not set in the default_settings.yaml file")        
 
         return Settings(
             enabled_rules=settings["enabled_rules"],

--- a/src/bitwarden_workflow_linter/utils.py
+++ b/src/bitwarden_workflow_linter/utils.py
@@ -113,12 +113,14 @@ class Settings:
     enabled_rules: list[dict[str, str]]
     approved_actions: dict[str, Action]
     actionlint_version: str
+    default_branch: str
 
     def __init__(
         self,
         enabled_rules: Optional[list[dict[str, str]]] = None,
         approved_actions: Optional[dict[str, dict[str, str]]] = None,
         actionlint_version: Optional[str] = None,
+        default_branch: Optional[str] = "main",
     ) -> None:
         """Settings object that can be overridden in settings.py.
 
@@ -144,6 +146,7 @@ class Settings:
         self.approved_actions = {
             name: Action(**action) for name, action in approved_actions.items()
         }
+        self.default_branch = default_branch
 
     @staticmethod
     def factory() -> SettingsFromFactory:
@@ -189,9 +192,11 @@ class Settings:
             ) as action_file:
                 settings["approved_actions"] = json.load(action_file)
 
-        
+        default_branch = settings.get("default_branch", "main")        
+
         return Settings(
             enabled_rules=settings["enabled_rules"],
             approved_actions=settings["approved_actions"],
             actionlint_version=actionlint_version,
+            default_branch=default_branch,
         )

--- a/src/bitwarden_workflow_linter/utils.py
+++ b/src/bitwarden_workflow_linter/utils.py
@@ -120,7 +120,7 @@ class Settings:
         enabled_rules: Optional[list[dict[str, str]]] = None,
         approved_actions: Optional[dict[str, dict[str, str]]] = None,
         actionlint_version: Optional[str] = None,
-        default_branch: str = None,
+        default_branch: Optional[str] = None,
     ) -> None:
         """Settings object that can be overridden in settings.py.
 

--- a/src/bitwarden_workflow_linter/utils.py
+++ b/src/bitwarden_workflow_linter/utils.py
@@ -120,7 +120,7 @@ class Settings:
         enabled_rules: Optional[list[dict[str, str]]] = None,
         approved_actions: Optional[dict[str, dict[str, str]]] = None,
         actionlint_version: Optional[str] = None,
-        default_branch: Optional[str] = "main",
+        default_branch: [str] = "main",
     ) -> None:
         """Settings object that can be overridden in settings.py.
 

--- a/tests/rules/test_check_pr_target.py
+++ b/tests/rules/test_check_pr_target.py
@@ -8,6 +8,8 @@ from src.bitwarden_workflow_linter.load import WorkflowBuilder
 from src.bitwarden_workflow_linter.rules.check_pr_target import (
     RuleCheckPrTarget,
 )
+from src.bitwarden_workflow_linter.models.workflow import Workflow
+from src.bitwarden_workflow_linter.utils import Settings
 
 yaml = YAML()
 message = "A check-run job must be included as a direct job dependency when pull_request_target is used and the workflow may only apply to runs on the main branch"
@@ -234,11 +236,53 @@ jobs:
 def fixture_rule():
     return RuleCheckPrTarget()
 
+@pytest.fixture
+def mock_workflow():
+    return Workflow(
+        on={
+            "pull_request_target": {
+                "branches": ["main"]
+            }
+        },
+        jobs={}
+    )
+def test_targets_main_branch_with_settings_yaml(mock_workflow):
+    settings = Settings({"default_branch": "main"})
+    rule = RuleCheckPrTarget(settings=settings)
+    assert rule.targets_main_branch(mock_workflow) is True
+
+def test_targets_custom_default_branch(mock_workflow):
+    settings = Settings(
+        enabled_rules=[],
+        approved_actions={},
+        actionlint_version="",
+        default_branch="production"
+    )
+    rule = RuleCheckPrTarget(settings=settings)
+    mock_workflow.on["pull_request_target"]["branches"] = ["production"]
+    assert rule.targets_main_branch(mock_workflow) is True
+
+def test_targets_main_branch_no_default_branch(mock_workflow):
+    settings = Settings({})
+    rule = RuleCheckPrTarget(settings=settings)
+    assert rule.targets_main_branch(mock_workflow) is True  # Defaults to "main"
+
+def test_targets_main_branch_incorrect_branch(mock_workflow):
+    settings = Settings({"default_branch": "main"})
+    rule = RuleCheckPrTarget(settings=settings)
+    mock_workflow.on["pull_request_target"]["branches"] = ["feature"]
+    assert rule.targets_main_branch(mock_workflow) is False
+
+def test_targets_main_branch_no_branches_specified(mock_workflow):
+    settings = Settings({"default_branch": "main"})
+    rule = RuleCheckPrTarget(settings=settings)
+    mock_workflow.on["pull_request_target"].pop("branches")
+    assert rule.targets_main_branch(mock_workflow) is False
+
 def test_rule_on_correct_workflow(rule, correct_workflow):
     result, message = rule.fn(correct_workflow)
     assert result is True
     assert message == ""
-
 
 def test_rule_on_no_checkworkflow(rule, no_check_workflow):
     result, message = rule.fn(no_check_workflow)


### PR DESCRIPTION
## 🎟️ Tracking
[BRE-609](https://bitwarden.atlassian.net/browse/BRE-609)

## 📔 Objective
update workflow linter to
- support overriding the default_branch name in a settings.yaml file to allow for repos whos default_branch is named something other than main ( production as an example )
- update the target_main_branch rule script to check for the overriden branch name, or default to main if not defined

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[BRE-609]: https://bitwarden.atlassian.net/browse/BRE-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ