### PR TITLE
[BRE-849] - Make Lint Command Take More Than One Argument

### DIFF
--- a/src/bitwarden_workflow_linter/cli.py
+++ b/src/bitwarden_workflow_linter/cli.py
@@ -38,7 +38,7 @@ def main(input_args: Optional[List[str]] = None) -> int:
     args = parser.parse_args(input_args)
 
     if args.command == "lint":
-        return linter_cmd.run(args.files, args.strict)
+        return linter_cmd.run(args.files[0], args.strict)
 
     if args.command == "actions":
         print(f"{'-'*50}\n!!bwwl actions is in BETA!!\n{'-'*50}")

--- a/src/bitwarden_workflow_linter/cli.py
+++ b/src/bitwarden_workflow_linter/cli.py
@@ -36,7 +36,8 @@ def main(input_args: Optional[List[str]] = None) -> int:
         raise SystemExit(parser.print_help())
 
     args = parser.parse_args(input_args)
-
+    if len(args.files) > 1:
+      raise parser.error("Only one -f / --files flag must be specified")
     if args.command == "lint":
         return linter_cmd.run(args.files[0], args.strict)
 

--- a/src/bitwarden_workflow_linter/lint.py
+++ b/src/bitwarden_workflow_linter/lint.py
@@ -51,7 +51,7 @@ class LinterCmd:
             action="store_true",
             help="return non-zero exit code on warnings as well as errors",
         )
-        parser_lint.add_argument("-f", "--files", nargs="+", action="append", help="files to lint")
+        parser_lint.add_argument("-f", "--files", nargs="+", action="append", required=True, help="files to lint")
         parser_lint.add_argument(
             "-o",
             "--output",

--- a/src/bitwarden_workflow_linter/lint.py
+++ b/src/bitwarden_workflow_linter/lint.py
@@ -51,7 +51,7 @@ class LinterCmd:
             action="store_true",
             help="return non-zero exit code on warnings as well as errors",
         )
-        parser_lint.add_argument("-f", "--files", action="append", help="files to lint")
+        parser_lint.add_argument("-f", "--files", nargs="+", action="append", help="files to lint")
         parser_lint.add_argument(
             "-o",
             "--output",


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/BRE-849
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective
- Updates the CLI to take more than one file argument.
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
