### PR TITLE
[BRE-1150] Ignoring node24 issue with actionlint

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -17,3 +17,4 @@ paths:
       # Ignore the specific error from shellcheck
       - 'shellcheck reported issue in this script: .+'
       - 'property "(secret_no_env_one|secret_one)" is not defined in object type.*' # Needed for sm-action tests with dynamic output
+      - 'invalid runner name "node24" at runs.using in ".*" action defined at ".*". valid runners are "composite", "docker", and "node20"' # Temporarily until actionlint support for node24 is released'

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -17,4 +17,4 @@ paths:
       # Ignore the specific error from shellcheck
       - 'shellcheck reported issue in this script: .+'
       - 'property "(secret_no_env_one|secret_one)" is not defined in object type.*' # Needed for sm-action tests with dynamic output
-      - 'invalid runner name "node24" at runs.using in ".*" action defined at ".*". valid runners are "composite", "docker", and "node20"' # Temporarily until actionlint support for node24 is released
+      - 'invalid runner name "node24" at runs.using in ".*" action defined at ".*". valid runners are "composite", "docker", and "node20"' # Temporary workaround until actionlint support for node24 is released

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -17,4 +17,4 @@ paths:
       # Ignore the specific error from shellcheck
       - 'shellcheck reported issue in this script: .+'
       - 'property "(secret_no_env_one|secret_one)" is not defined in object type.*' # Needed for sm-action tests with dynamic output
-      - 'invalid runner name "node24" at runs.using in ".*" action defined at ".*". valid runners are "composite", "docker", and "node20"' # Temporarily until actionlint support for node24 is released'
+      - 'invalid runner name "node24" at runs.using in ".*" action defined at ".*". valid runners are "composite", "docker", and "node20"' # Temporarily until actionlint support for node24 is released


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-1150](https://bitwarden.atlassian.net/browse/BRE-1150)
## 📔 Objective

Temporarily ignoring node24 action error until actionlint support is released<br/>
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes

[BRE-1150]: https://bitwarden.atlassian.net/browse/BRE-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ