### PR TITLE
Add `errors-only` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ options:
   -h, --help      show this help message and exit
   -v, --verbose
 ```
+
+#### lint subcommand
+
+```bash
+usage: bwwl lint [-h] [-s | -e] -f FILES [FILES ...] [-o OUTPUT]
+
+options:
+  -h, --help            show this help message and exit
+  -s, --strict          return non-zero exit code on warnings as well as errors
+  -e, --errors-only     only show and fail on errors; warnings are suppressed
+                        from output and do not affect the exit code
+  -f, --files FILES     files or directories to lint
+  -o, --output OUTPUT   output format: [stdout|json|md] (default: stdout)
+```
+
+> **Note:** `--strict` and `--errors-only` are mutually exclusive.
 ## Pre-commit Hook Setup
 
 ### Navigate to the `.git/hooks` directory in the repository you wish to lint:

--- a/src/bitwarden_workflow_linter/cli.py
+++ b/src/bitwarden_workflow_linter/cli.py
@@ -37,7 +37,7 @@ def main(input_args: Optional[List[str]] = None) -> int:
 
     args = parser.parse_args(input_args)
     if args.command == "lint":
-        return linter_cmd.run([file for file_list in args.files for file in file_list], args.strict)
+        return linter_cmd.run([file for file_list in args.files for file in file_list], args.strict, args.errors_only)
 
     if args.command == "actions":
         print(f"{'-'*50}\n!!bwwl actions is in BETA!!\n{'-'*50}")

--- a/src/bitwarden_workflow_linter/lint.py
+++ b/src/bitwarden_workflow_linter/lint.py
@@ -7,7 +7,7 @@ import os
 from typing import Optional
 
 from .load import WorkflowBuilder, Rules
-from .utils import LintFinding, Settings
+from .utils import LintFinding, LintLevels, Settings
 
 
 class LinterCmd:
@@ -45,11 +45,19 @@ class LinterCmd:
             "lint",
             help="Verify that a GitHub Action Workflow follows all of the Rules.",
         )
-        parser_lint.add_argument(
+        exclusive = parser_lint.add_mutually_exclusive_group()
+        exclusive.add_argument(
             "-s",
             "--strict",
             action="store_true",
             help="return non-zero exit code on warnings as well as errors",
+        )
+        exclusive.add_argument(
+            "-e",
+            "--errors-only",
+            action="store_true",
+            default=False,
+            help="only show and fail on errors; warnings are suppressed from output and do not affect the exit code",
         )
         parser_lint.add_argument("-f", "--files", nargs="+", action="append", required=True, help="files to lint")
         parser_lint.add_argument(
@@ -78,7 +86,7 @@ class LinterCmd:
             return 0
         return max(findings, key=lambda finding: finding.level.code).level.code
 
-    def lint_file(self, filename: str) -> int:
+    def lint_file(self, filename: str, errors_only: bool) -> int:
         """Lint a single workflow.
 
         Run all of the Workflow, Job, and Step level rules that have been enabled.
@@ -110,6 +118,9 @@ class LinterCmd:
                         findings.append(rule.execute(step))
 
         findings = list(filter(lambda a: a is not None, findings))
+
+        if errors_only:
+            findings = list(filter(lambda f: f.level == LintLevels.ERROR, findings))
 
         if len(findings) > 0:
             for finding in findings:
@@ -149,7 +160,7 @@ class LinterCmd:
 
         return sorted(set(workflow_files))
 
-    def run(self, input_files: list[str], strict: bool = False) -> int:
+    def run(self, input_files: list[str], strict: bool = False, errors_only: bool = False) -> int:
         """Execute the LinterCmd.
 
         Args:
@@ -157,6 +168,8 @@ class LinterCmd:
             list of file names or directory names.
           strict:
             fail on WARNING instead of succeed
+          errors_only:
+            only show errors, not warning level findings
 
         Returns
           The return_code for the entire CLI to indicate success/failure
@@ -167,7 +180,7 @@ class LinterCmd:
             files_with_issues = []
             return_code = 0
             for file in files:
-                return_value = self.lint_file(file)
+                return_value = self.lint_file(file, errors_only)
                 if return_value > 0:
                     files_with_issues.append(file)
                     return_code = max(return_code, return_value)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,6 +1,10 @@
 """Test src/bitwarden_workflow_linter/lint.py."""
 
+import argparse
+
 import pytest
+
+from unittest.mock import MagicMock
 
 from src.bitwarden_workflow_linter.lint import LinterCmd
 from src.bitwarden_workflow_linter.utils import Settings, LintFinding, LintLevels
@@ -45,3 +49,55 @@ def test_get_max_error_level(settings):
         )
         == 2
     )
+
+
+@pytest.fixture(name="linter_with_mock_rules")
+def fixture_linter_with_mock_rules(settings):
+    linter = LinterCmd(settings=settings)
+    linter.rules.workflow = []
+    linter.rules.job = []
+    linter.rules.step = []
+    return linter
+
+
+def _make_rule(finding):
+    rule = MagicMock()
+    rule.execute.return_value = finding
+    return rule
+
+
+def test_lint_file_errors_only_suppresses_warnings(linter_with_mock_rules, capsys):
+    linter = linter_with_mock_rules
+    linter.rules.workflow = [
+        _make_rule(LintFinding("warning finding", LintLevels.WARNING)),
+        _make_rule(LintFinding("error finding", LintLevels.ERROR)),
+    ]
+
+    result = linter.lint_file("tests/fixtures/test.yml", errors_only=True)
+    captured = capsys.readouterr()
+
+    assert result == 2
+    assert "error finding" in captured.out
+    assert "warning finding" not in captured.out
+
+
+def test_lint_file_errors_only_warnings_only_returns_zero(linter_with_mock_rules, capsys):
+    linter = linter_with_mock_rules
+    linter.rules.workflow = [
+        _make_rule(LintFinding("warning finding", LintLevels.WARNING)),
+    ]
+
+    result = linter.lint_file("tests/fixtures/test.yml", errors_only=True)
+    captured = capsys.readouterr()
+
+    assert result == 0
+    assert "warning finding" not in captured.out
+
+
+def test_strict_and_errors_only_are_mutually_exclusive():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    LinterCmd.extend_parser(subparsers)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["lint", "--strict", "--errors-only", "-f", "file.yml"])


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Add an `--errors-only` flag to the linter that suppresses warning-level findings from output. This change was inspired by the [following Claude code skill PR comment.](https://github.com/bitwarden/ai-plugins/pull/75#discussion_r3012055378)

The flag is mutually exclusive with `--strict` which is highlighted in the `--help` command and in the updated `README.md`.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
