### PR TITLE
[BRE-2080] Add bitwarden/deploy to zizmor allowed repos

### DIFF
--- a/zizmor.yml
+++ b/zizmor.yml
@@ -6,6 +6,7 @@ rules:
         bitwarden/ios/*: ref-pin
         bitwarden/mobile-learning-sandbox/*: ref-pin
         bitwarden/android/*: ref-pin
+        bitwarden/deploy/*: ref-pin
   dangerous-triggers: # Often caused by our pull_request_target usage that we scrutinize manually
     disable: true
   secrets-inherit: # With our use of AKV for secrets, this is less relevant


### PR DESCRIPTION
## 🎟️ Tracking

[BRE-2080](https://bitwarden.atlassian.net/browse/BRE-2080)

## 📔 Objective

Add bitwarden/deploy to zizmor allowed repos<br/>

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

[BRE-2080]: https://bitwarden.atlassian.net/browse/BRE-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ